### PR TITLE
Add a Windows version of the native closure compiler

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,6 @@ packages/google-closure-compiler-osx/compiler filter=lfs diff=lfs merge=lfs -tex
 packages/google-closure-compiler-osx/compiler.* filter=lfs diff=lfs merge=lfs -text
 packages/google-closure-compiler-linux/compiler filter=lfs diff=lfs merge=lfs -text
 packages/google-closure-compiler-linux/compiler.* filter=lfs diff=lfs merge=lfs -text
+packages/google-closure-compiler-windows/compiler filter=lfs diff=lfs merge=lfs -text
+packages/google-closure-compiler-windows/compiler.* filter=lfs diff=lfs merge=lfs -text
 packages/google-closure-compiler-java/compiler.* filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,28 +1,27 @@
 name: Build Binaries
 
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   build:
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [12.x]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: true
         lfs: true
-    - uses: actions/setup-java@v1
-      with:
-        java-version: '8.0.x' # The JDK version to make available on the path.
+    - uses: seanmiddleditch/gha-setup-vsdevenv@master
+      if: ${{ matrix.platform == 'windows-latest' }}
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2-beta
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
-      run: yarn install
+      run: yarn
     - name: Remove OS Restrictions
       run: node ./tasks/remove-os-restrictions.js
     - name: Upgrade Packages to Specified Closure Version
@@ -31,14 +30,17 @@ jobs:
       run: yarn build
     - name: Link Native Binary
       run: |
-        (cd packages/google-closure-compiler-osx && yarn link)
-        (cd packages/google-closure-compiler-linux && yarn link)
-        (cd packages/google-closure-compiler && yarn link "@kristoferbaxter/google-closure-compiler-osx")
-        (cd packages/google-closure-compiler && yarn link "@kristoferbaxter/google-closure-compiler-linux")
+        (yarn link --cwd packages/google-closure-compiler-osx)
+        (yarn link --cwd packages/google-closure-compiler-linux)
+        (yarn link --cwd packages/google-closure-compiler-windows)
+        (yarn link "@ampproject/google-closure-compiler-osx" --cwd packages/google-closure-compiler)
+        (yarn link "@ampproject/google-closure-compiler-linux" --cwd packages/google-closure-compiler)
+        (yarn link "@ampproject/google-closure-compiler-windows" --cwd packages/google-closure-compiler)
     - name: Test Changes
       run: yarn test
     - name: Push Changes
       uses: kristoferbaxter/github-push-action@master
+      if: ${{ github.event_name == 'push' }}
       with:
         force: true
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kristoferbaxter/amp-closure-compiler",
+  "name": "@ampproject/amp-closure-compiler",
   "version": "1.0.0",
   "private": true,
   "workspaces": {
@@ -9,10 +9,11 @@
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kristoferbaxter/amp-closure-compiler.git"
+    "url": "https://github.com/ampproject/amp-closure-compiler.git"
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "del": "5.1.0",
     "google-closure-compiler-java": "20200517.0.0",
     "kleur": "4.0.2",
     "lerna": "^3.22.1",
@@ -20,9 +21,9 @@
     "semver": "^7.x"
   },
   "scripts": {
-    "build": "./tasks/build.sh",
-    "test": "./tasks/test.sh",
-    "restrict": "./tasks/restrict.sh",
-    "clean": "./tasks/clean.sh"
+    "build": "node ./tasks/build.js",
+    "test": "node ./tasks/test.js",
+    "restrict": "node ./tasks/restrict.js",
+    "clean": "node ./tasks/clean.js"
   }
 }

--- a/packages/google-closure-compiler-java/package.json
+++ b/packages/google-closure-compiler-java/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kristoferbaxter/google-closure-compiler-java",
+  "name": "@ampproject/google-closure-compiler-java",
   "version": "20200517.2.1",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "build": "echo \"google-closure-compiler-java build\"",
-    "test": "./test.js",
+    "test": "node ./test.js",
     "clean": "echo \"google-closure-compiler-java clean\"",
     "restrict": "echo \"google-closure-compiler-java restrict\""
   }

--- a/packages/google-closure-compiler-osx/package.json
+++ b/packages/google-closure-compiler-osx/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kristoferbaxter/google-closure-compiler-osx",
+  "name": "@ampproject/google-closure-compiler-osx",
   "version": "20200517.2.1",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
@@ -26,11 +26,8 @@
     "kleur": "4.0.2"
   },
   "scripts": {
-    "build": "./build-image.js",
-    "test": "./test.js",
-    "restrict": "./add-os-restrictions.js"
-  },
-  "os": [
-    "darwin"
-  ]
+    "build": "node ./build-image.js",
+    "test": "node ./test.js",
+    "restrict": "node ./add-os-restrictions.js"
+  }
 }

--- a/packages/google-closure-compiler-windows/add-os-restrictions.js
+++ b/packages/google-closure-compiler-windows/add-os-restrictions.js
@@ -25,17 +25,9 @@
 const {promises: fs} = require('fs');
 const path = require('path');
 
-const RESTRICTED_OS_PACKAGES = [
-  './packages/google-closure-compiler-osx',
-  './packages/google-closure-compiler-linux',
-  './packages/google-closure-compiler-windows',
-];
-
 (async function() {
-  for await (const pkg of RESTRICTED_OS_PACKAGES) {
-    const packagePath = path.resolve(pkg, 'package.json');
-    const packageContents = JSON.parse(await fs.readFile(packagePath, 'utf8'));
-    delete packageContents.os;
-    await fs.writeFile(packagePath, JSON.stringify(packageContents, null, 2) + '\n', 'utf8');
-  }
+  const packagePath = path.resolve(__dirname, 'package.json');
+  const packageContents = JSON.parse(await fs.readFile(packagePath, 'utf8'));
+  packageContents.os = ['win32'];
+  await fs.writeFile(packagePath, JSON.stringify(packageContents, null, 2) + '\n', 'utf8');
 })();

--- a/packages/google-closure-compiler-windows/build-image.js
+++ b/packages/google-closure-compiler-windows/build-image.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/*
+ * Copyright 2019 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+/**
+ * @fileoverview
+ *
+ * Check to see if the graal native image for this platform should be built
+ */
+
+const fs = require('fs');
+const path = require('path');
+const kleur = require('kleur');
+const {spawn} = require('child_process');
+
+if (fs.existsSync(path.resolve(__dirname, 'compiler'))) {
+  process.stdout.write(kleur.dim('  google-closure-compiler-windows binary already exists\n'));
+  process.exit(0);
+} else if (process.platform !== 'win32') {
+  process.stdout.write(kleur.dim('  google-closure-compiler-windows build wrong platform\n'));
+  process.exit(0);
+} else {
+  process.stdout.write(kleur.dim('  google-closure-compiler-windows building image\n'));
+  spawn('node ../../tasks/build-native-compiler.js', [], {shell: 'cmd', stdio: 'inherit'});
+}

--- a/packages/google-closure-compiler-windows/index.js
+++ b/packages/google-closure-compiler-windows/index.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2019 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const path = require('path');
+module.exports = path.resolve(__dirname, 'compiler.exe');

--- a/packages/google-closure-compiler-windows/package.json
+++ b/packages/google-closure-compiler-windows/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ampproject/google-closure-compiler-linux",
+  "name": "@ampproject/google-closure-compiler-windows",
   "version": "20200517.2.1",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
@@ -9,11 +9,10 @@
     "compiler",
     "optimizer",
     "minifier",
-    "closure",
-    "java"
+    "closure"
   ],
   "files": [
-    "compiler",
+    "compiler.exe",
     "index.js",
     "package.json",
     "readme.md"
@@ -22,9 +21,7 @@
     "x64",
     "x86"
   ],
-  "devDependencies": {
-    "kleur": "4.0.2"
-  },
+  "preferUnplugged": true,
   "scripts": {
     "build": "node ./build-image.js",
     "test": "node ./test.js",

--- a/packages/google-closure-compiler-windows/readme.md
+++ b/packages/google-closure-compiler-windows/readme.md
@@ -1,0 +1,5 @@
+# google-closure-compiler-windows
+
+Windows native platform distribution of Closure Compiler.
+
+For cli scripts, build tool plugins and more see the [main distribution](https://www.npmjs.com/package/google-closure-compiler).

--- a/packages/google-closure-compiler-windows/test.js
+++ b/packages/google-closure-compiler-windows/test.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/*
+ * Copyright 2019 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const {spawn} = require('child_process');
+const nativeImagePath = require('./');
+const kleur = require('kleur');
+
+process.stdout.write('google-closure-compiler-windows\n');
+if (process.platform !== 'win32') {
+  process.stdout.write(`  ${kleur.dim('skipping tests - incorrect platform')}\n`);
+} else if (fs.existsSync(nativeImagePath)) {
+  process.stdout.write(`  ${kleur.green('✓')} ${kleur.dim('compiler binary exists')}\n`);
+  new Promise(
+      (resolve, reject) => {
+        const compilerTest = spawn(
+          nativeImagePath,
+            ['--version'],
+            {stdio: 'inherit'});
+        compilerTest.on('error', err => {
+          reject(err);
+        });
+        compilerTest.on('close', exitCode => {
+          if (exitCode != 0) {
+            return reject('non zero exit code');
+          }
+          process.stdout.write(
+              `  ${kleur.green('✓')} ${kleur.dim('compiler version successfully reported')}\n`);
+          resolve();
+        });
+      })
+      .then(() => new Promise((resolve, reject) => {
+        const compilerTest = spawn(
+          nativeImagePath,
+            ['--help'],
+            {stdio: 'inherit'});
+        compilerTest.on('error', err => {
+          reject(err);
+        });
+        compilerTest.on('close', exitCode => {
+          if (exitCode != 0) {
+            return reject('non zero exit code');
+          }
+          process.stdout.write(
+              `  ${kleur.green('✓')} ${kleur.dim('compiler help successfully reported')}\n`);
+          resolve();
+        });
+      }))
+      .catch(err => {
+        process.stderr.write((err || '').toString() + '\n');
+        process.stdout.write(`  ${kleur.red('compiler execution tests failed')}\n`);
+        process.exitCode = 1;
+      });
+} else {
+  process.stdout.write(`  ${kleur.red('compiler binary does not exist')}\n`);
+  process.exitCode = 1;
+}

--- a/packages/google-closure-compiler/README.md
+++ b/packages/google-closure-compiler/README.md
@@ -101,7 +101,7 @@ Additionally, community members have created plugins leveraging this library.
 Override the path before first use.
 
 ```
-const Compiler = require('@kristoferbaxter/google-closure-compiler');
+const Compiler = require('@ampproject/google-closure-compiler');
 
 Compiler.prototype.javaPath = '/node_modules/MODULE_NAME/jre/jre1.8.0_131.jre/Contents/Home/bin/java';
 
@@ -123,7 +123,7 @@ npm install closure-gun
 Then point the package to use closure-gun rather than the JDK.
 
 ```js
-const compilerPackage = require('@kristoferbaxter/google-closure-compiler');
+const compilerPackage = require('@ampproject/google-closure-compiler');
 
 compilerPackage.compiler.JAR_PATH = undefined;
 compilerPackage.compiler.prototype.javaPath = './node_modules/.bin/closure-gun'
@@ -138,7 +138,7 @@ In addition, it exposes a static property with the path to the compiler jar file
 ### Java Version
 
 ```js
-const ClosureCompiler = require('@kristoferbaxter/google-closure-compiler').compiler;
+const ClosureCompiler = require('@ampproject/google-closure-compiler').compiler;
 
 console.log(ClosureCompiler.COMPILER_PATH); // absolute path to the compiler jar
 console.log(ClosureCompiler.CONTRIB_PATH); // absolute path to the contrib folder which contain externs
@@ -156,7 +156,7 @@ const compilerProcess = closureCompiler.run((exitCode, stdOut, stdErr) => {
 ### JavaScript Version
 
 ```js
-const ClosureCompiler = require('@kristoferbaxter/google-closure-compiler').jsCompiler;
+const ClosureCompiler = require('@ampproject/google-closure-compiler').jsCompiler;
 
 console.log(ClosureCompiler.CONTRIB_PATH); // absolute path to the contrib folder which contains externs
 

--- a/packages/google-closure-compiler/docs/grunt.md
+++ b/packages/google-closure-compiler/docs/grunt.md
@@ -6,7 +6,7 @@ Task targets, files and options may be specified according to the grunt
 Include the plugin in your Gruntfile.js:
 
 ```js
-require('@kristoferbaxter/google-closure-compiler').grunt(grunt, {
+require('@ampproject/google-closure-compiler').grunt(grunt, {
   platform: ['native', 'java', 'javascript'],
   compile_in_batches: require('os').cpus().length
 });
@@ -19,7 +19,7 @@ The option can be either a string or an array where the first supported platform
 ## Basic Configuration Example:
 
 ```js
-require('@kristoferbaxter/google-closure-compiler').grunt(grunt);
+require('@ampproject/google-closure-compiler').grunt(grunt);
 
 // Project configuration.
 grunt.initConfig({
@@ -43,7 +43,7 @@ grunt.initConfig({
 
 ```js
 
-const compilerPackage = require('@kristoferbaxter/google-closure-compiler');
+const compilerPackage = require('@ampproject/google-closure-compiler');
 compilerPackage.grunt(grunt);
 
 // Project configuration.
@@ -72,7 +72,7 @@ Some users may wish to pass the java vm extra arguments - such as to specify the
 be allocated. Both the grunt and gulp plugins support this.
 
 ```js
-require('@kristoferbaxter/google-closure-compiler').grunt(grunt, {
+require('@ampproject/google-closure-compiler').grunt(grunt, {
   platform: 'java',
   extraArguments: ['-Xms2048m']
 });

--- a/packages/google-closure-compiler/docs/gulp.md
+++ b/packages/google-closure-compiler/docs/gulp.md
@@ -7,7 +7,7 @@ Options are a direct match to the compiler flags without the leading "--".
 ## Basic Configuration Example:
 
 ```js
-const closureCompiler = require('@kristoferbaxter/google-closure-compiler').gulp();
+const closureCompiler = require('@ampproject/google-closure-compiler').gulp();
 
 gulp.task('js-compile', function () {
   return gulp.src('./src/js/**/*.js', {base: './'})
@@ -35,7 +35,7 @@ compiler. With large source sets this may require a large amount of memory.
 Closure-compiler can natively expand file globs which will greatly alleviate this issue.
 
 ```js
-const compilerPackage = require('@kristoferbaxter/google-closure-compiler');
+const compilerPackage = require('@ampproject/google-closure-compiler');
 const closureCompiler = compilerPackage.gulp();
 
 gulp.task('js-compile', function () {
@@ -63,7 +63,7 @@ this behavior.
 The gulp plugin supports gulp sourcemaps.
 
 ```js
-const closureCompiler = require('@kristoferbaxter/google-closure-compiler').gulp();
+const closureCompiler = require('@ampproject/google-closure-compiler').gulp();
 const sourcemaps = require('gulp-sourcemaps');
 
 gulp.task('js-compile', function () {
@@ -87,7 +87,7 @@ Some users may wish to pass the java vm extra arguments - such as to specify the
 be allocated. Both the grunt and gulp plugins support this.
 
 ```js
-const closureCompiler = require('@kristoferbaxter/google-closure-compiler').gulp({
+const closureCompiler = require('@ampproject/google-closure-compiler').gulp({
   extraArguments: ['-Xms2048m']
 });
 ```

--- a/packages/google-closure-compiler/lib/node/closure-compiler.js
+++ b/packages/google-closure-compiler/lib/node/closure-compiler.js
@@ -24,7 +24,7 @@
 'use strict';
 
 const spawn = require('child_process').spawn;
-const compilerPath = require('@kristoferbaxter/google-closure-compiler-java');
+const compilerPath = require('@ampproject/google-closure-compiler-java');
 const path = require('path');
 const contribPath = path.resolve(__dirname, '../../contrib');
 

--- a/packages/google-closure-compiler/lib/utils.js
+++ b/packages/google-closure-compiler/lib/utils.js
@@ -16,12 +16,23 @@
 'use strict';
 
 function getNativeImagePath() {
-  const suffix = process.platform === 'darwin' ? 'osx' : 'linux';
-
+  if (process.platform === 'darwin') {
+    try {
+      return require('@ampproject/google-closure-compiler-osx');
+    } catch (e) {
+      return;
+    }
+  }
+  if (process.platform === 'win32') {
+    try {
+      return require('@ampproject/google-closure-compiler-windows');
+    } catch (e) {
+      return;
+    }
+  }
   try {
-    return require(`@kristoferbaxter/google-closure-compiler-${suffix}`);
+    return require('@ampproject/google-closure-compiler-linux');
   } catch (e) {
-    return;
   }
 }
 

--- a/packages/google-closure-compiler/package.json
+++ b/packages/google-closure-compiler/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kristoferbaxter/google-closure-compiler",
+  "name": "@ampproject/google-closure-compiler",
   "version": "20200517.2.1",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "bin": {
@@ -16,15 +16,15 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@kristoferbaxter/google-closure-compiler-java": "^20200517.2.1",
+    "@ampproject/google-closure-compiler-java": "^20200517.2.1",
     "kleur": "4.0.2",
     "minimist": "1.x",
     "vinyl": "2.x",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },
   "optionalDependencies": {
-    "@kristoferbaxter/google-closure-compiler-linux": "^20200517.2.1",
-    "@kristoferbaxter/google-closure-compiler-osx": "^20200517.2.1"
+    "@ampproject/google-closure-compiler-linux": "^20200517.2.1",
+    "@ampproject/google-closure-compiler-osx": "^20200517.2.1"
   },
   "devDependencies": {
     "gulp": "4.x",

--- a/tasks/build-native-compiler.js
+++ b/tasks/build-native-compiler.js
@@ -19,16 +19,28 @@
 // Note: We download graal since it's 800MB+ of disk space per platform.
 const fs = require("fs");
 const path = require("path");
-const runCommand = require("./run-command.js");
+const { execOrDie } = require("./exec.js");
+
+const graalOsMap = {
+  linux: 'linux',
+  darwin: 'darwin',
+  win32: 'windows',
+}
+
+const graalPackageSuffixMap = {
+  linux: 'tar.gz',
+  darwin: 'tar.gz',
+  win32: 'zip',
+}
 
 const TEMP_PATH = path.resolve(__dirname, "..", "temp");
-const GRAAL_OS = process.platform;
+const GRAAL_OS = graalOsMap[process.platform];
 const GRAAL_VERSION = "20.1.0";
-const GRAAL_FOLDER = `graalvm-ce-java8-${GRAAL_OS}-amd64-${GRAAL_VERSION}`;
-const GRAAL_PACKAGE_SUFFIX = "tar.gz";
+const GRAAL_FOLDER = `graalvm-ce-java11-${GRAAL_OS}-amd64-${GRAAL_VERSION}`;
+const GRAAL_PACKAGE_SUFFIX = graalPackageSuffixMap[process.platform];
 const GRAAL_URL =
   process.env.GRAAL_URL ||
-  `https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${GRAAL_VERSION}/${GRAAL_FOLDER}.tar.gz`;
+  `https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${GRAAL_VERSION}/${GRAAL_FOLDER}.${GRAAL_PACKAGE_SUFFIX}`;
 
 const NATIVE_IMAGE_BUILD_ARGS = [
   "-H:+JNI",
@@ -42,12 +54,12 @@ const NATIVE_IMAGE_BUILD_ARGS = [
     __dirname,
     "reflection-config.json"
   )}`,
-  "-H:IncludeResources=(externs.zip)|(.*(js|txt))",
+  "-H:IncludeResources=\"(externs.zip)|(.*(js|txt))\"",
   "-H:+ReportExceptionStackTraces",
   "--initialize-at-build-time",
   "-jar",
   path.resolve(process.cwd(), "..", "..", "dist", "compiler.jar"),
-];
+].join(' ');
 
 // This script should catch and handle all rejected promises.
 // If it ever fails to do so, report that and exit immediately.
@@ -56,9 +68,8 @@ process.on("unhandledRejection", (error) => {
   process.exit(1);
 });
 
+// TODO(rsimha): Refactor and split up this file.
 (function () {
-  console.log(NATIVE_IMAGE_BUILD_ARGS);
-
   // Build graal from source
   if (!fs.existsSync(TEMP_PATH)) {
     fs.mkdirSync(TEMP_PATH);
@@ -69,7 +80,7 @@ process.on("unhandledRejection", (error) => {
   // Download Graal
   const GRAAL_ARCHIVE_FILE = `${GRAAL_FOLDER}.${GRAAL_PACKAGE_SUFFIX}`;
   // Build the compiler native image.
-  let pathParts = [TEMP_PATH, `graalvm-ce-java8-${GRAAL_VERSION}`];
+  let pathParts = [TEMP_PATH, `graalvm-ce-java11-${GRAAL_VERSION}`];
   if (GRAAL_OS === "darwin") {
     pathParts.push("Contents", "Home", "bin");
   } else {
@@ -85,22 +96,24 @@ process.on("unhandledRejection", (error) => {
       .then(() => {
         // Download graal and extract the contents
         if (!fs.existsSync(path.resolve(TEMP_PATH, GRAAL_ARCHIVE_FILE))) {
-          process.stdout.write(`Downloading graal from ${GRAAL_URL}\n`);
-          return runCommand(
+          console.log(`Downloading graal from ${GRAAL_URL}`);
+          execOrDie(
             `curl --fail --show-error --location --progress-bar --output ${GRAAL_ARCHIVE_FILE} ${GRAAL_URL}`,
             { cwd: TEMP_PATH }
           );
         }
       })
       .then(() => {
+        console.log(`Extracting ${GRAAL_ARCHIVE_FILE}`);
         if (GRAAL_PACKAGE_SUFFIX === "tar.gz") {
-          return runCommand(`tar -xzf ${GRAAL_ARCHIVE_FILE}`, {
-            cwd: TEMP_PATH,
-          });
+          execOrDie(`tar -xzf ${GRAAL_ARCHIVE_FILE}`, {cwd: TEMP_PATH});
         }
-        return runCommand(`7z x -y ${GRAAL_ARCHIVE_FILE}`, { cwd: TEMP_PATH });
+        execOrDie(`7z x -y ${GRAAL_ARCHIVE_FILE}`, { cwd: TEMP_PATH });
       })
-      .then(() => runCommand(`${GRAAL_GU_PATH} install native-image`));
+      .then(() => {
+        console.log(`Installing native image from ${GRAAL_GU_PATH}`);
+        execOrDie(`${GRAAL_GU_PATH} install native-image`);
+      });
   }
 
   // Build the compiler native image.
@@ -109,10 +122,19 @@ process.on("unhandledRejection", (error) => {
     `native-image${GRAAL_OS === "windows" ? ".cmd" : ""}`
   );
 
-  buildSteps
-    .then(() => runCommand(GRAAL_NATIVE_IMAGE_PATH, NATIVE_IMAGE_BUILD_ARGS))
-    .catch((e) => {
-      console.error(e);
-      process.exit(1);
+  return buildSteps
+    .then(() => {
+      console.log(`Testing native image:`);
+      fs.writeFileSync('Foo.java', 'public class Foo { public static void main(String[] args){ System.out.println("Hello amp-closure-compiler!"); } }\n');
+      execOrDie(GRAAL_OS === "windows" ? 'type Foo.java' : 'cat Foo.java')
+      execOrDie('javac -version');
+      execOrDie('javac Foo.java');
+      execOrDie(`${GRAAL_NATIVE_IMAGE_PATH} Foo`);
+      execOrDie(GRAAL_OS === "windows" ? 'dir' : 'ls -la')
+      execOrDie(GRAAL_OS === "windows" ? 'foo.exe' : './foo')
+    })
+    .then(() => {
+      console.log(`Building native image: ${GRAAL_NATIVE_IMAGE_PATH} ${NATIVE_IMAGE_BUILD_ARGS}`);
+      execOrDie(`${GRAAL_NATIVE_IMAGE_PATH} ${NATIVE_IMAGE_BUILD_ARGS}`, {'stdio': 'inherit'});
     });
 })();

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"use strict";
+
+const { execOrDie } = require("./exec.js");
+
+/**
+ * Run the build commands and fail the script if any of them failed
+ **/
+(async function () {
+  execOrDie('node ./tasks/build-compiler.js');
+  execOrDie('yarn workspaces run build');
+})();

--- a/tasks/build.sh
+++ b/tasks/build.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-# Run the build commands and fail the script if any of them failed
-./tasks/build-compiler.js "$@" && yarn workspaces run build "$@"

--- a/tasks/bump-version.js
+++ b/tasks/bump-version.js
@@ -23,12 +23,14 @@ const { platform } = require('os');
 
 const isLinux = platform() === 'linux';
 const isOSX = platform() === 'darwin';
+const isWindows = platform() === 'win32';
 
 const PACKAGE_LOCATIONS = [
   "./packages/google-closure-compiler/package.json",
   "./packages/google-closure-compiler-java/package.json",
   isLinux ? "./packages/google-closure-compiler-linux/package.json" : null,
   isOSX ? "./packages/google-closure-compiler-osx/package.json" : null,
+  isWindows ? "./packages/google-closure-compiler-windows/package.json" : null,
 ].filter(Boolean);
 
 // This script should catch and handle all rejected promises.
@@ -40,8 +42,8 @@ process.on("unhandledRejection", (error) => {
 
 /**
  * Update a json file with the closure version sepecified, give caller a chance to modify the content too.
- * @param {string} location 
- * @param {string} closureVersion 
+ * @param {string} location
+ * @param {string} closureVersion
  * @param {(parsed: JSON) => JSON} additionalModificationMethod
  * @return {Promise<void>}
  */
@@ -67,7 +69,7 @@ async function updatePackage(location, closureVersion, additionalModificationMet
 
   // 2. Update Lerna configuration with the valid Closure Version
   await updatePackage("./lerna.json", closureVersion, (parsed) => parsed);
-  
+
   // 2. Update Major version within each package.
   for await (const packageLocation of PACKAGE_LOCATIONS) {
     await updatePackage(packageLocation, closureVersion, (parsed) => {
@@ -75,29 +77,38 @@ async function updatePackage(location, closureVersion, additionalModificationMet
       const hatClosureVersion = "^" + closureVersion;
       if (
         parsed.dependencies &&
-        parsed.dependencies["@kristoferbaxter/google-closure-compiler-java"]
+        parsed.dependencies["@ampproject/google-closure-compiler-java"]
       ) {
         parsed.dependencies[
-          "@kristoferbaxter/google-closure-compiler-java"
+          "@ampproject/google-closure-compiler-java"
         ] = hatClosureVersion;
       }
       if (parsed.optionalDependencies) {
         if (
           parsed.optionalDependencies[
-            "@kristoferbaxter/google-closure-compiler-linux"
+            "@ampproject/google-closure-compiler-linux"
           ]
         ) {
           parsed.optionalDependencies[
-            "@kristoferbaxter/google-closure-compiler-linux"
+            "@ampproject/google-closure-compiler-linux"
           ] = hatClosureVersion;
         }
         if (
           parsed.optionalDependencies[
-            "@kristoferbaxter/google-closure-compiler-osx"
+            "@ampproject/google-closure-compiler-osx"
           ]
         ) {
           parsed.optionalDependencies[
-            "@kristoferbaxter/google-closure-compiler-osx"
+            "@ampproject/google-closure-compiler-osx"
+          ] = hatClosureVersion;
+        }
+        if (
+          parsed.optionalDependencies[
+            "@ampproject/google-closure-compiler-windows"
+          ]
+        ) {
+          parsed.optionalDependencies[
+            "@ampproject/google-closure-compiler-windows"
           ] = hatClosureVersion;
         }
       }

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"use strict";
+
+const del = require('del');
+const { exec } = require("./exec.js");
+
+/**
+ * Remove all build artifacts and OS restrictions
+ **/
+(async function () {
+  const pathsToDelete = [
+    './temp',
+    './build',
+    './packages/google-closure-compiler-java/compiler.jar',
+    './packages/google-closure-compiler-linux/compiler.jar',
+    './packages/google-closure-compiler-linux/compiler',
+    './packages/google-closure-compiler-osx/compiler.jar',
+    './packages/google-closure-compiler-osx/compiler',
+    './packages/google-closure-compiler-windows/compiler.jar',
+    './packages/google-closure-compiler-windows/compiler',
+  ];
+  await del(pathsToDelete)
+  exec('node ./tasks/remove-os-restrictions.js');
+})();
+
+

--- a/tasks/clean.sh
+++ b/tasks/clean.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-rm -rf ./temp
-rm -rf ./build
-rm ./packages/google-closure-compiler-java/compiler.jar
-rm ./packages/google-closure-compiler-linux/compiler.jar
-rm ./packages/google-closure-compiler-linux/compiler
-rm ./packages/google-closure-compiler-osx/compiler.jar
-rm ./packages/google-closure-compiler-osx/compiler
-./tasks/remove-os-restrictions.js

--- a/tasks/restrict.js
+++ b/tasks/restrict.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"use strict";
+
+const { exec } = require("./exec.js");
+
+/**
+ * Restrict the usage of each optional dependency per OS
+ **/
+(async function () {
+  exec('yarn workspaces run restrict');
+})();

--- a/tasks/restrict.sh
+++ b/tasks/restrict.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-# Restrict the usage of each optional dependency per OS
-yarn workspaces run restrict "$@"

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"use strict";
+
+const { execOrDie } = require("./exec.js");
+
+/**
+ * Run the test commands and fail the script if any of them failed
+ **/
+(async function () {
+  execOrDie('yarn workspaces run test');
+  execOrDie('mocha');
+})();

--- a/tasks/test.sh
+++ b/tasks/test.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-# Run the test commands and fail the script if any of them failed
-EXIT_STATUS=0
-yarn workspaces run test "$@" || EXIT_STATUS=$?
-mocha "$@" || EXIT_STATUS=$?
-exit $EXIT_STATUS

--- a/yarn.lock
+++ b/yarn.lock
@@ -809,10 +809,31 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@nodelib/fs.scandir@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
+  integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.3"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
+  integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
+
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
+  integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.3"
+    fastq "^1.6.0"
 
 "@octokit/auth-token@^2.4.0":
   version "2.4.2"
@@ -998,6 +1019,14 @@ agentkeepalive@^3.4.1:
   integrity sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==
   dependencies:
     humanize-ms "^1.2.1"
+
+aggregate-error@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
+  integrity sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==
+  dependencies:
+    clean-stack "^2.0.0"
+    indent-string "^4.0.0"
 
 ajv@^6.5.5:
   version "6.12.2"
@@ -1380,6 +1409,13 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
+braces@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  dependencies:
+    fill-range "^7.0.1"
+
 browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
@@ -1583,6 +1619,11 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+clean-stack@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
+  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
 cli-cursor@^2.1.0:
   version "2.1.0"
@@ -2063,6 +2104,20 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+del@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-5.1.0.tgz#d9487c94e367410e6eff2925ee58c0c84a75b3a7"
+  integrity sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==
+  dependencies:
+    globby "^10.0.1"
+    graceful-fs "^4.2.2"
+    is-glob "^4.0.1"
+    is-path-cwd "^2.2.0"
+    is-path-inside "^3.0.1"
+    p-map "^3.0.0"
+    rimraf "^3.0.0"
+    slash "^3.0.0"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -2112,6 +2167,13 @@ dir-glob@^2.2.2:
   integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
   dependencies:
     path-type "^3.0.0"
+
+dir-glob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+  dependencies:
+    path-type "^4.0.0"
 
 dot-prop@^3.0.0:
   version "3.0.0"
@@ -2429,10 +2491,29 @@ fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
+fast-glob@^3.0.3:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
+  integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+    picomatch "^2.2.1"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+fastq@^1.6.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.8.0.tgz#550e1f9f59bbc65fe185cb6a9b4d95357107f481"
+  integrity sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==
+  dependencies:
+    reusify "^1.0.4"
 
 figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -2460,6 +2541,13 @@ fill-range@^4.0.0:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
+
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
 
 find-up@3.0.0, find-up@^3.0.0:
   version "3.0.0"
@@ -2766,7 +2854,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.0.0:
+glob-parent@^5.0.0, glob-parent@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
@@ -2861,6 +2949,20 @@ global-prefix@^1.0.1:
     ini "^1.3.4"
     is-windows "^1.0.1"
     which "^1.2.14"
+
+globby@^10.0.1:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-10.0.2.tgz#277593e745acaa4646c3ab411289ec47a0392543"
+  integrity sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.0.3"
+    glob "^7.1.3"
+    ignore "^5.1.1"
+    merge2 "^1.2.3"
+    slash "^3.0.0"
 
 globby@^9.2.0:
   version "9.2.0"
@@ -3144,6 +3246,11 @@ ignore@^4.0.3:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
+ignore@^5.1.1:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
+  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
@@ -3416,10 +3523,25 @@ is-number@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
   integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
 
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
 is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
+
+is-path-cwd@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
+  integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
+
+is-path-inside@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz#f5220fc82a3e233757291dddc9c5877f2a1f3017"
+  integrity sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
 
 is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
@@ -4012,7 +4134,7 @@ meow@^7.0.0:
     type-fest "^0.13.1"
     yargs-parser "^18.1.3"
 
-merge2@^1.2.3:
+merge2@^1.2.3, merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -4035,6 +4157,14 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
+
+micromatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
 
 mime-db@1.44.0:
   version "1.44.0"
@@ -4689,6 +4819,13 @@ p-map@^2.1.0:
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
 
+p-map@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-3.0.0.tgz#d704d9af8a2ba684e2600d9a215983d4141a979d"
+  integrity sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==
+  dependencies:
+    aggregate-error "^3.0.0"
+
 p-pipe@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-pipe/-/p-pipe-1.2.0.tgz#4b1a11399a11520a67790ee5a0c1d5881d6befe9"
@@ -4869,10 +5006,20 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+picomatch@^2.0.5, picomatch@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
+  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -5359,6 +5506,11 @@ retry@^0.10.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
   integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
 
+reusify@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
@@ -5366,10 +5518,22 @@ rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 run-async@^2.2.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
+
+run-parallel@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
+  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
@@ -5516,6 +5680,11 @@ slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
   integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
+
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
 slide@^1.1.6:
   version "1.1.6"
@@ -6024,6 +6193,13 @@ to-regex-range@^2.1.0:
   dependencies:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
+
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
 
 to-regex@^3.0.1, to-regex@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
This PR adds a native closure compiler for Windows.

**Highlights:**

- Completes migration of `amp-closure-compiler` repo from `@kristoferbaxter` org to `@ampproject`
- Adds a Windows workflow for building a Java compiler and using it to generate a native executable 
- Rewrites generic build / test / restrict / clean shell scripts in nodejs so they can run on Windows
- Populates `packages/google-closure-compiler-windows` with code from parent repo
- Modifies GraalVM install and native-image generation to be Windows compliant
- Adds step to set up VC dev environment on Windows
- Modifies push step to be conditional, since it doesn't work on PRs from forks

Unblocks https://github.com/ampproject/amphtml/pull/29115
Partial fix for https://github.com/ampproject/amphtml/issues/27570