### PR TITLE
Remove references to missing LFS objects from repo

### DIFF
--- a/packages/google-closure-compiler-java/compiler.jar
+++ b/packages/google-closure-compiler-java/compiler.jar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:715e1c1a03fc0cb8de194c8fcf541626a3ac1c45deaac5bfaaadfd392b71e026
-size 11128913

--- a/packages/google-closure-compiler-linux/compiler
+++ b/packages/google-closure-compiler-linux/compiler
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:106dc309b856da4be05b77905a4bcc0a0a8771935c6bfd833f63027041806c1b
-size 40556816

--- a/packages/google-closure-compiler-linux/compiler.jar
+++ b/packages/google-closure-compiler-linux/compiler.jar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:715e1c1a03fc0cb8de194c8fcf541626a3ac1c45deaac5bfaaadfd392b71e026
-size 11128913

--- a/packages/google-closure-compiler-osx/compiler
+++ b/packages/google-closure-compiler-osx/compiler
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e3e3991f497191164c2c9f08f979bddb65089f55feddaa5c858f6c9391877cf8
-size 38942596

--- a/packages/google-closure-compiler-osx/compiler.jar
+++ b/packages/google-closure-compiler-osx/compiler.jar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5240b349693d1ca107b5376bfb804be7a8901af74b263b7fdfe8798df59ab886
-size 11128913


### PR DESCRIPTION
Partial fix for #3

Coming up: Regenerate these compiler files and freshly check in new versions.