### PR TITLE
Fix auto-push of compiler binaries

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,10 +38,9 @@ jobs:
         (yarn link "@ampproject/google-closure-compiler-windows" --cwd packages/google-closure-compiler)
     - name: Test Changes
       run: yarn test
-    - name: Push Changes
-      uses: kristoferbaxter/github-push-action@master
+    - uses: stefanzweifel/git-auto-commit-action@v4
       if: ${{ github.event_name == 'push' }}
       with:
-        force: true
+        commit_message: Push new compiler binaries
+        file_pattern: packages/google-closure-compiler-*/compiler*
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: ${{ github.head_ref }}


### PR DESCRIPTION
This PR attempts to fix the push step for newly built native compiler binaries that currently doesn't work on Windows.

See https://github.com/ampproject/amp-closure-compiler/runs/942141559?check_suite_focus=true

```sh
Run kristoferbaxter/github-push-action@master
Error: Unable to locate executable file: d:\a\_actions\kristoferbaxter\github-push-action\master\start.sh. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.
    at Object.<anonymous> (d:\a\_actions\kristoferbaxter\github-push-action\master\dist\index.js:417:27)
    at Generator.next (<anonymous>)
    at fulfilled (d:\a\_actions\kristoferbaxter\github-push-action\master\dist\index.js:245:58)
Error: Unable to locate executable file: d:\a\_actions\kristoferbaxter\github-push-action\master\start.sh. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.
    at Object.<anonymous> (d:\a\_actions\kristoferbaxter\github-push-action\master\dist\index.js:417:27)
    at Generator.next (<anonymous>)
    at fulfilled (d:\a\_actions\kristoferbaxter\github-push-action\master\dist\index.js:245:58)
  Post Run actions/checkout@v2
```