### PR TITLE
Fix compiler binary pushes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Test Changes
       run: yarn test
     - uses: stefanzweifel/git-auto-commit-action@v4
+      if: ${{ github.event_name == 'push' }}
       with:
         commit_message: Push new compiler binaries
         push_options: '--force'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,8 +39,8 @@ jobs:
     - name: Test Changes
       run: yarn test
     - uses: stefanzweifel/git-auto-commit-action@v4
-      if: ${{ github.event_name == 'push' }}
       with:
         commit_message: Push new compiler binaries
+        push_options: '--force'
         file_pattern: packages/google-closure-compiler-*/compiler*
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        skip_dirty_check: true


### PR DESCRIPTION
Follow up to #6.

Two changes:
- The `github_token` option is not necessary. Removing it.
- The different jobs need to merge their binaries into one commit, so we must use `--force` and skip the dirty branch check.
