### PR TITLE
Do separate binary pushes for each OS

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: stefanzweifel/git-auto-commit-action@v4
       if: ${{ github.event_name == 'push' }}
       with:
-        commit_message: Push new compiler binaries
+        commit_message: "Push new compiler binaries on ${{ matrix.platform }}"
         push_options: '--force'
         file_pattern: packages/google-closure-compiler-*/compiler*
         skip_dirty_check: true


### PR DESCRIPTION
This PR splits the compiler binary pushes for each OS into separate commits so a) they actually work, and b) they can be tested independently.

Addresses https://github.com/ampproject/amp-closure-compiler/pull/7#discussion_r466054549