### PR TITLE
Push new compiler binaries sequentially after each `amp-closure-compiler` PR is merged to `master`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,7 +1,11 @@
-name: Build Binaries
-
-on: [pull_request, push]
-
+name: Build and Push Native Compiler Binaries
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   build:
     strategy:
@@ -13,7 +17,6 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@v2
       with:
-        submodules: true
         lfs: true
     - name: Set up Windows Dev Environment (skipped on Linux and macOS)
       uses: seanmiddleditch/gha-setup-vsdevenv@master
@@ -40,6 +43,6 @@ jobs:
         (yarn link "@ampproject/google-closure-compiler-windows" --cwd packages/google-closure-compiler)
     - name: Test Changes
       run: yarn test
-    - name: Push Native Binaries
+    - name: Push Native Binary for ${{ matrix.platform }}
       if: ${{ github.event_name == 'push' }}
-      run: node ./tasks/push-binaries.js
+      run: node ./tasks/push-binary.js

--- a/packages/google-closure-compiler-linux/build-image.js
+++ b/packages/google-closure-compiler-linux/build-image.js
@@ -26,9 +26,7 @@ const path = require('path');
 const kleur = require('kleur');
 const {spawn} = require('child_process');
 
-if (fs.existsSync(path.resolve(__dirname, 'compiler'))) {
-  process.stdout.write(kleur.dim('  google-closure-compiler-linux binary already exists\n'));
-} else if (process.platform !== 'linux') {
+if (process.platform !== 'linux') {
   process.stdout.write(kleur.dim('  google-closure-compiler-linux build wrong platform\n'));
 } else {
   process.stdout.write(kleur.dim('  google-closure-compiler-linux building image\n'));

--- a/packages/google-closure-compiler-osx/build-image.js
+++ b/packages/google-closure-compiler-osx/build-image.js
@@ -26,9 +26,7 @@ const path = require('path');
 const kleur = require('kleur');
 const {spawn} = require('child_process');
 
-if (fs.existsSync(path.resolve(__dirname, 'compiler'))) {
-  process.stdout.write(kleur.dim('  google-closure-compiler-osx binary already exists\n'));
-} else if (process.platform !== 'darwin') {
+if (process.platform !== 'darwin') {
   process.stdout.write(kleur.dim('  google-closure-compiler-osx build wrong platform\n'));
 } else {
   process.stdout.write(kleur.dim('  google-closure-compiler-osx building image\n'));

--- a/packages/google-closure-compiler-windows/build-image.js
+++ b/packages/google-closure-compiler-windows/build-image.js
@@ -26,10 +26,7 @@ const path = require('path');
 const kleur = require('kleur');
 const {spawn} = require('child_process');
 
-if (fs.existsSync(path.resolve(__dirname, 'compiler'))) {
-  process.stdout.write(kleur.dim('  google-closure-compiler-windows binary already exists\n'));
-  process.exit(0);
-} else if (process.platform !== 'win32') {
+if (process.platform !== 'win32') {
   process.stdout.write(kleur.dim('  google-closure-compiler-windows build wrong platform\n'));
   process.exit(0);
 } else {

--- a/tasks/push-binary.js
+++ b/tasks/push-binary.js
@@ -29,15 +29,19 @@ const platformOsMap = {
 }
 
 /**
- * Push all compiler binaries built on this OS after syncing to origin
+ * Push the compiler binary built on this OS after syncing to origin
  **/
-(async function () {
+async function main() {
   const osName = platformOsMap[process.platform];
-  const compilerBinaries = path.join('packages', `google-closure-compiler-${osName}`, 'compiler*')
-  execOrDie(`git add ${compilerBinaries}`);
-  execOrDie(`git commit -m "Push new ${osName} compiler binaries"`);
-  execOrDie('git pull --rebase');
+  const nativeCompilerGlob = path.join('packages', `google-closure-compiler-${osName}`, 'compiler*')
+
+  execOrDie(`git config --global user.name "${process.env.GITHUB_ACTOR}"`);
+  execOrDie(`git config --global user.email "${process.env.GITHUB_ACTOR}@users.noreply.github.com"`);
+  execOrDie(`git add ${nativeCompilerGlob}`);
+  execOrDie(`git commit -m "Updated compiler binary for ${osName}"`);
+  execOrDie('git checkout -- .');
+  execOrDie('git pull origin --rebase');
   execOrDie('git push');
-})();
+}
 
-
+main();


### PR DESCRIPTION
**PR highlights:**

- Updates build code to always generate a new compiler binary for every change to the `amp-closure-compiler` repo
- Updates push workflow as follows:
    - Create a commit with the updated compiler binary for the current OS
    - Revert all other local changes (extraneous test files, intermediate build output, etc.)
    - Pull latest changes from `origin` and rebase local commit on them
    - Push all local commits to `origin`, including the newly built compiler binaries