### PR TITLE
Upgrade closure to 20200719.0.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "20200517.2.1",
+  "version": "20200719.0.0",
   "ignoreChanges": [
     "**/compiler/**"
   ]

--- a/package.json
+++ b/package.json
@@ -3,8 +3,12 @@
   "version": "1.0.0",
   "private": true,
   "workspaces": {
-    "packages": ["packages/*"],
-    "nohoist": ["**/mocha"]
+    "packages": [
+      "packages/*"
+    ],
+    "nohoist": [
+      "**/mocha"
+    ]
   },
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "repository": {
@@ -14,7 +18,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "del": "5.1.0",
-    "google-closure-compiler-java": "20200517.0.0",
+    "google-closure-compiler-java": "20200719.0.0",
     "kleur": "4.0.2",
     "lerna": "^3.22.1",
     "mocha": "^6.x",

--- a/packages/google-closure-compiler-java/package.json
+++ b/packages/google-closure-compiler-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler-java",
-  "version": "20200517.2.1",
+  "version": "20200719.0.0",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/google-closure-compiler-linux/package.json
+++ b/packages/google-closure-compiler-linux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler-linux",
-  "version": "20200517.2.1",
+  "version": "20200719.0.0",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/google-closure-compiler-osx/package.json
+++ b/packages/google-closure-compiler-osx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler-osx",
-  "version": "20200517.2.1",
+  "version": "20200719.0.0",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/google-closure-compiler-windows/package.json
+++ b/packages/google-closure-compiler-windows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler-windows",
-  "version": "20200517.2.1",
+  "version": "20200719.0.0",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/google-closure-compiler/package.json
+++ b/packages/google-closure-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler",
-  "version": "20200517.2.1",
+  "version": "20200719.0.0",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "bin": {
     "google-closure-compiler": "cli.js"
@@ -16,15 +16,15 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@ampproject/google-closure-compiler-java": "^20200517.2.1",
+    "@ampproject/google-closure-compiler-java": "20200719.0.0",
     "kleur": "4.0.2",
     "minimist": "1.x",
     "vinyl": "2.x",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },
   "optionalDependencies": {
-    "@ampproject/google-closure-compiler-linux": "^20200517.2.1",
-    "@ampproject/google-closure-compiler-osx": "^20200517.2.1"
+    "@ampproject/google-closure-compiler-linux": "20200719.0.0",
+    "@ampproject/google-closure-compiler-osx": "20200719.0.0"
   },
   "devDependencies": {
     "gulp": "4.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2985,10 +2985,10 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-google-closure-compiler-java@20200517.0.0:
-  version "20200517.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-java/-/google-closure-compiler-java-20200517.0.0.tgz#778370c22273c9085f4cf959ce063f8f112c02ac"
-  integrity sha512-JVZBiyyXwcYi6Yc3lO6dF2hMLJA4OzPm4/mgsem/tF1vk2HsWTnL3GTaBsPB2ENVZp0hoqsd4KgpPiG9ssNWxw==
+google-closure-compiler-java@20200719.0.0:
+  version "20200719.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-java/-/google-closure-compiler-java-20200719.0.0.tgz#04b0e087e7257ba0f5847010d8f05b5715d36723"
+  integrity sha512-/alYc8OC9zAETZ2m10OhtqI+PAs2b8y6cLn2VlN/53dHrCC6gKqj7Ajun/GAVAUOW4HMRMnpBYdCJgMLpAniSA==
 
 graceful-fs@4.X, graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
   version "4.2.4"


### PR DESCRIPTION
After this PR is merged, assuming the native binaries are correctly built and pushed, we will have to publish a new release that can be consumed by `ampproject/amphtml`.