### PR TITLE
Fix build paths for native compilers and test push code during PR checks

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -42,5 +42,4 @@ jobs:
     - name: Test Changes
       run: yarn test
     - name: Push Native Binary for ${{ matrix.platform }}
-      if: ${{ github.event_name == 'push' }}
       run: node ./tasks/push-binary.js

--- a/tasks/push-binary.js
+++ b/tasks/push-binary.js
@@ -31,8 +31,14 @@ async function main() {
   execOrDie(`git add ${nativeCompilerGlob}`);
   execOrDie(`git commit -m "📦 Updated compiler binary for ${osName}"`);
   execOrDie('git checkout -- .');
-  execOrDie('git pull origin --rebase');
-  execOrDie('git push');
+  if (process.env.GITHUB_EVENT_NAME == 'pull_request') {
+    console.log('Verifying files in last commit...')
+    execOrDie('git diff --stat HEAD^..HEAD');
+  } else if (process.env.GITHUB_EVENT_NAME == 'push') {
+    console.log('Syncing to origin and pushing commit...')
+    execOrDie('git pull origin --rebase');
+    execOrDie('git push');
+  }
 }
 
 main();


### PR DESCRIPTION
Follow up to #14. Required in order to generate binaries in the correct directory. This PR also verifies the workflow to push binaries during PR checks (without actually doing the push).