### PR TITLE
Restore per-OS dependencies, replace LFS binaries with non-LFS equivalents

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,0 @@
-packages/google-closure-compiler-osx/compiler filter=lfs diff=lfs merge=lfs -text
-packages/google-closure-compiler-osx/compiler.* filter=lfs diff=lfs merge=lfs -text
-packages/google-closure-compiler-linux/compiler filter=lfs diff=lfs merge=lfs -text
-packages/google-closure-compiler-linux/compiler.* filter=lfs diff=lfs merge=lfs -text
-packages/google-closure-compiler-windows/compiler filter=lfs diff=lfs merge=lfs -text
-packages/google-closure-compiler-windows/compiler.* filter=lfs diff=lfs merge=lfs -text
-packages/google-closure-compiler-java/compiler.* filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
-      with:
-        lfs: true
     - name: Set up Windows Dev Environment (skipped on Linux and macOS)
       uses: seanmiddleditch/gha-setup-vsdevenv@master
       if: ${{ matrix.platform == 'windows-latest' }}

--- a/packages/google-closure-compiler-java/compiler.jar
+++ b/packages/google-closure-compiler-java/compiler.jar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b0fff1ff2994401be8da811a642001257e8674df26c480db18eb9dcc9540cb4
-size 11205261

--- a/packages/google-closure-compiler-linux/compiler
+++ b/packages/google-closure-compiler-linux/compiler
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:20e7a8a202ceb6873045e39395be9b482ef4db9f9a007d3494b2046dc8a4200a
-size 41460816

--- a/packages/google-closure-compiler-linux/compiler.jar
+++ b/packages/google-closure-compiler-linux/compiler.jar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b0fff1ff2994401be8da811a642001257e8674df26c480db18eb9dcc9540cb4
-size 11205261

--- a/packages/google-closure-compiler-osx/compiler
+++ b/packages/google-closure-compiler-osx/compiler
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1aaa40f05e01da7c103a68e85e5cd17df40cc52c524c3e57dd80ee4ee69726d3
-size 40505704

--- a/packages/google-closure-compiler-osx/compiler.jar
+++ b/packages/google-closure-compiler-osx/compiler.jar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:197c936d47ea8d9ba616e4c2929db7a88b7a2ebbaff7d4fffa92abb2b599c128
-size 11205261

--- a/packages/google-closure-compiler-windows/compiler.exe
+++ b/packages/google-closure-compiler-windows/compiler.exe
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5653baa4db2a32782ee2ac6560b9edc6bac67bac8f680e9b695a3d3f937171f9
-size 40977408

--- a/packages/google-closure-compiler-windows/compiler.exp
+++ b/packages/google-closure-compiler-windows/compiler.exp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:791bc0c03a401429cf46c8da3a074ba999d6ebbe9442c0573619aaad8e30bc32
-size 68385

--- a/packages/google-closure-compiler-windows/compiler.jar
+++ b/packages/google-closure-compiler-windows/compiler.jar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bbb06ae61eedc3823a95049ee0ab849ec4ff1e014422f7e54b0829fd7a90d3e0
-size 11205261

--- a/packages/google-closure-compiler-windows/compiler.lib
+++ b/packages/google-closure-compiler-windows/compiler.lib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:12721dd4e2a68a201769af871af45c362ea0c87f83cb68ef91fbfc408adc8183
-size 112984

--- a/packages/google-closure-compiler-windows/compiler.pdb
+++ b/packages/google-closure-compiler-windows/compiler.pdb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:baa8cef800953c54e0d76941e2cd4e2691961a5cda1f2749a501be5da41fb86c
-size 1150976

--- a/packages/google-closure-compiler-windows/compiler.stripped.pdb
+++ b/packages/google-closure-compiler-windows/compiler.stripped.pdb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ae043e8d3a1bd86254add9dee14534dbbdf3af2d690be630f19855d5266bd29
-size 307200

--- a/packages/google-closure-compiler/package.json
+++ b/packages/google-closure-compiler/package.json
@@ -16,10 +16,16 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
+    "@ampproject/google-closure-compiler-java": "20200719.0.0",
     "kleur": "4.0.2",
     "minimist": "1.x",
     "vinyl": "2.x",
     "vinyl-sourcemaps-apply": "^0.2.0"
+  },
+  "optionalDependencies": {
+    "@ampproject/google-closure-compiler-linux": "20200719.0.0",
+    "@ampproject/google-closure-compiler-osx": "20200719.0.0",
+    "@ampproject/google-closure-compiler-windows": "20200719.0.0"
   },
   "devDependencies": {
     "gulp": "4.x",

--- a/packages/google-closure-compiler/yarn.lock
+++ b/packages/google-closure-compiler/yarn.lock
@@ -2,6 +2,26 @@
 # yarn lockfile v1
 
 
+"@ampproject/google-closure-compiler-java@20200719.0.0":
+  version "20200719.0.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/google-closure-compiler-java/-/google-closure-compiler-java-20200719.0.0.tgz#a580b1f8bf2f23c4ca6d50718c80418e6d10194d"
+  integrity sha512-Ni4DiTH1joBZ0LxTTb5xvz+LzyUgpM/hRBg/WYl5NPzTdXG8CZGFTZsgdiWHTj4Jo5V9Q/rgt+q5vMCncGo7Pg==
+
+"@ampproject/google-closure-compiler-linux@20200719.0.0":
+  version "20200719.0.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/google-closure-compiler-linux/-/google-closure-compiler-linux-20200719.0.0.tgz#e6349e46232fb8c8eab2f651f90d3acdb9a60c0f"
+  integrity sha512-Sws4d1d67lv12l8Rum0SlLRZ8LgxYqKikysSGaszbzlmocMOOsTsYJcDDzWiR7qSM95Wh9JpIE/VuIO8pYcIPg==
+
+"@ampproject/google-closure-compiler-osx@20200719.0.0":
+  version "20200719.0.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/google-closure-compiler-osx/-/google-closure-compiler-osx-20200719.0.0.tgz#6fee36766e4f189d9d355be222c55806a831a109"
+  integrity sha512-HadcHAIgaIbUFlbavs9owUMHCX4Ori3EO0dSlcUdhXXCc3AanESrMwzV35QfqQ9qbfwbaiHJAhbORCNpeDMVAA==
+
+"@ampproject/google-closure-compiler-windows@20200719.0.0":
+  version "20200719.0.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/google-closure-compiler-windows/-/google-closure-compiler-windows-20200719.0.0.tgz#74389abc775fb4a1d9105d3d9caa5385147e5b7e"
+  integrity sha512-x7fSJo8iu+x3/f5vg1t3hxxCgL5uYpk0+XXvMcTkF8rS3s3Oswa9sVPwJVSK0VZMNR1r9kb1x2rOxI2hu5SG7g==
+
 "@gulp-sourcemaps/identity-map@1.X":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@gulp-sourcemaps/identity-map/-/identity-map-1.0.2.tgz#1e6fe5d8027b1f285dc0d31762f566bccd73d5a9"

--- a/tasks/push-binary.js
+++ b/tasks/push-binary.js
@@ -26,17 +26,17 @@ const { getOsName } = require('./utils.js');
  **/
 async function main() {
   const osName = getOsName();
-  const javaCompilerGlob = path.join('packages', 'google-closure-compiler-java', 'compiler*')
-  const nativeCompilerGlob = path.join('packages', `google-closure-compiler-${osName}`, 'compiler*')
+  const javaCompiler = path.join('packages', 'google-closure-compiler-java', 'compiler.jar')
+  const nativeCompiler = path.join('packages', `google-closure-compiler-${osName}`, osName == 'windows' ? 'compiler.exe' : 'compiler')
   execOrDie(`git config --global user.name "${process.env.GITHUB_ACTOR}"`);
   execOrDie(`git config --global user.email "${process.env.GITHUB_ACTOR}@users.noreply.github.com"`);
   // It's sufficient to update the Java compiler just once
   if (osName == 'linux') {
-    execOrDie(`git add ${javaCompilerGlob}`);
-    execOrDie('git commit -m "📦 Updated Java compiler binary"');
+    execOrDie(`git add ${javaCompiler}`);
+    execOrDie('git commit -m "📦 Updated java compiler binary"');
   }
-  execOrDie(`git add ${nativeCompilerGlob}`);
-  execOrDie(`git commit -m "📦 Updated compiler binary for ${osName}"`);
+  execOrDie(`git add ${nativeCompiler}`);
+  execOrDie(`git commit -m "📦 Updated ${osName} compiler binary"`);
   execOrDie('git checkout -- .');
   if (process.env.GITHUB_EVENT_NAME == 'pull_request') {
     console.log('Verifying files in new commit(s)...')


### PR DESCRIPTION
When this package was first published to npm, the (optional) dependencies on the Java and the per-OS compilers broke because they had never been published. Now that initial versions have been published, this PR restores the required dependencies.

In addition, this PR removes all LFS compiler binaries. Once merged to `master`, they will automatically be replaced by non-LFS equivalents. (This is okay because the binaries are no longer > 100MB in size.)

Finally, this PR cleans up all unnecessary intermediate files, and makes sure that only the binary that's actually invoked during compilation is merged to each sub-package directory.

