### PR TITLE
Clean local branch before pull / rebase / push

### DIFF
--- a/tasks/push-binary.js
+++ b/tasks/push-binary.js
@@ -37,6 +37,7 @@ async function main() {
   }
   execOrDie(`git add ${nativeCompiler}`);
   execOrDie(`git commit -m "📦 Updated ${osName} compiler binary"`);
+  execOrDie('git clean -d  -f .');
   execOrDie('git checkout -- .');
   if (process.env.GITHUB_EVENT_NAME == 'pull_request') {
     console.log('Verifying files in new commit(s)...')


### PR DESCRIPTION
This PR is a follow up to #19, and makes the pushing of commits more resilient to failures by first cleaning up any untracked files on the local branch.

This should fix errors that may appear during a fresh upload, like when old binaries are deleted for some reason.

![image](https://user-images.githubusercontent.com/26553114/90458050-480cc200-e0cb-11ea-950c-8c3f310c76cb.png)
