### PR TITLE
Update `PUBLISH.md`

### DIFF
--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -1,5 +1,26 @@
-1. Make sure `git lfs` is installed. `git lfs install`.
-2. Pull the latest files `git lfs pull`. 
-3. Ensure tests `yarn test` pass.
-5. Run `npx lerna version --force-publish='*'`.
-6. Run `npm publish --otp={}` in each package. (TODO: Fix this please.)
+## Publishing a new version of `@ampproject/amp-closure-compiler`
+
+Sync latest changes from `origin`.
+
+```
+git pull
+```
+
+Run tests locally and make sure they pass.
+```
+yarn test
+```
+
+Bump versions of all local packages (select an appropriate incremental version).
+```
+npx lerna version --exact --force-publish='*'
+```
+
+Publish a new version for each package. (TODO: Make this a single invocation.)
+```
+npm publish --access public --otp <OTP> packages/google-closure-compiler
+npm publish --access public --otp <OTP> packages/google-closure-compiler-java
+npm publish --access public --otp <OTP> packages/google-closure-compiler-linux
+npm publish --access public --otp <OTP> packages/google-closure-compiler-osx
+npm publish --access public --otp <OTP> packages/google-closure-compiler-windows
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/amp-closure-compiler",
-  "version": "20200719.0.0",
+  "version": "1.0.0",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR updates the publishing instructions for the packages in the `ampproject/amp-closure-compiler` repo. It turns out we don't have to publish the main repo to npm, only the packages. Therefore, we also restore the version in the root `package.json` to `1.0.0`.

Since this PR is non-blocking, I will test out the workflow described in it and let this go through code review before merging.

**Update:** Workflow tested and found to work. Compiler binaries were successfully published to npm and downloaded to `amphtml`.

![image](https://user-images.githubusercontent.com/26553114/90464040-7219b080-e0da-11ea-8d4e-aff90d45ea09.png)


**Coming up next:** Figure out why the July version of closure compiler does not work, fix it, and add tests for it. (I suspect that the custom AMP command line runner code needs a fix.)