### PR TITLE
Upgrade to September's closure version

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "npmClient": "yarn",
-  "version": "20200517.3.0",
+  "version": "20200920.0.0",
   "ignoreChanges": [
     "**/compiler/**"
   ]

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "vinyl-sourcemaps-apply": "0.2.1"
   },
   "dependencies": {
-    "google-closure-compiler-java": "20200517.0.0"
+    "google-closure-compiler-java": "20200920.0.0"
   },
   "scripts": {
     "build": "node ./tasks/build.js",

--- a/packages/google-closure-compiler-java/package.json
+++ b/packages/google-closure-compiler-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler-java",
-  "version": "20200517.3.0",
+  "version": "20200920.0.0",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/google-closure-compiler-linux/package.json
+++ b/packages/google-closure-compiler-linux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler-linux",
-  "version": "20200517.3.0",
+  "version": "20200920.0.0",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/google-closure-compiler-osx/package.json
+++ b/packages/google-closure-compiler-osx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler-osx",
-  "version": "20200517.3.0",
+  "version": "20200920.0.0",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/google-closure-compiler-windows/package.json
+++ b/packages/google-closure-compiler-windows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler-windows",
-  "version": "20200517.3.0",
+  "version": "20200920.0.0",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/google-closure-compiler/package.json
+++ b/packages/google-closure-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler",
-  "version": "20200517.3.0",
+  "version": "20200920.0.0",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "bin": {
     "google-closure-compiler": "cli.js"
@@ -16,12 +16,12 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@ampproject/google-closure-compiler-java": "20200517.3.0"
+    "@ampproject/google-closure-compiler-java": "20200920.0.0"
   },
   "optionalDependencies": {
-    "@ampproject/google-closure-compiler-linux": "20200517.3.0",
-    "@ampproject/google-closure-compiler-osx": "20200517.3.0",
-    "@ampproject/google-closure-compiler-windows": "20200517.3.0"
+    "@ampproject/google-closure-compiler-linux": "20200920.0.0",
+    "@ampproject/google-closure-compiler-osx": "20200920.0.0",
+    "@ampproject/google-closure-compiler-windows": "20200920.0.0"
   },
   "scripts": {
     "test": "mocha"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,10 +1258,10 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-google-closure-compiler-java@20200517.0.0:
-  version "20200517.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-java/-/google-closure-compiler-java-20200517.0.0.tgz#778370c22273c9085f4cf959ce063f8f112c02ac"
-  integrity sha512-JVZBiyyXwcYi6Yc3lO6dF2hMLJA4OzPm4/mgsem/tF1vk2HsWTnL3GTaBsPB2ENVZp0hoqsd4KgpPiG9ssNWxw==
+google-closure-compiler-java@20200920.0.0:
+  version "20200920.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-java/-/google-closure-compiler-java-20200920.0.0.tgz#23519b14e004f2a9eda4f5b887842ae46ad7022e"
+  integrity sha512-q8m/+QLBWrzjg5VZ2b4B628zDvbi0Gyenj9bvZQlPY7mqj68HXhe5aOfKzZO7vXgHDXMvsvI3v/1g5mPAku/5w==
 
 graceful-fs@4.X, graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.2:
   version "4.2.4"


### PR DESCRIPTION
Closure upgrade: v20200517 -> v20200920

This PR will auto-generate native binaries for all platforms and test them during PR check. Once merged, the native binaries in this repo will be auto-updated with newly built artifacts. We can then upgrade the dependency in `amphtml`.

Anticipated fix for #22 (assuming the answer to https://github.com/ampproject/amp-closure-compiler/issues/22#issuecomment-696896619 is yes)