### PR TITLE
Skip checks for new version tags and when 'skip CI' is part of the commit message

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
 jobs:
+  if: ${{ !startsWith(github.event.head_commit.message, 'v202') && !contains(github.event.head_commit.message, 'skip CI') }}
   build:
     strategy:
       matrix:


### PR DESCRIPTION
This PR will prevent duplicate binary uploads when we bump the version using lerna as described in [`PUBLISH.md`](https://github.com/ampproject/amp-closure-compiler/blob/master/PUBLISH.md#L14-L17).

As a result, CI runs will no longer have to be manually canceled for commits like https://github.com/ampproject/amp-closure-compiler/commit/bdf652f0ea952c117fbd7aad902fc76ba52a0f41.

![image](https://user-images.githubusercontent.com/26553114/93936538-549cbf80-fcf4-11ea-95e5-6adcb0c689fc.png)

