### PR TITLE
Upgrade to November's Closure Compiler

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - master
 jobs:
-  if: ${{ !startsWith(github.event.head_commit.message, 'v202') && !contains(github.event.head_commit.message, 'skip CI') }}
+  if: ${{ (github.event.head_commit && !startsWith(github.event.head_commit.message, 'v202') && !contains(github.event.head_commit.message, 'skip CI')) || !github.event.head_commit }}
   build:
     strategy:
       matrix:

--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - master
 jobs:
-  # if: ${{ !startsWith(github.event.head_commit.message, 'v202') && !contains(github.event.head_commit.message, 'skip CI') }}
+  if: ${{ !startsWith(github.event.head_commit.message, 'v202') && !contains(github.event.head_commit.message, 'skip CI') }}
   build:
     strategy:
       matrix:

--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - master
 jobs:
-  if: ${{ !startsWith(github.event.head_commit.message, 'v202') && !contains(github.event.head_commit.message, 'skip CI') }}
+  # if: ${{ !startsWith(github.event.head_commit.message, 'v202') && !contains(github.event.head_commit.message, 'skip CI') }}
   build:
     strategy:
       matrix:

--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -7,8 +7,8 @@ on:
     branches:
       - master
 jobs:
-  if: ${{ (github.event.head_commit && !startsWith(github.event.head_commit.message, 'v202') && !contains(github.event.head_commit.message, 'skip CI')) || !github.event.head_commit }}
   build:
+    if: ${{ !startsWith(github.event.head_commit.message, 'v202') && !contains(github.event.head_commit.message, 'skip CI') }}
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]

--- a/README.md
+++ b/README.md
@@ -7,3 +7,24 @@ This is not intended to be used outside the AMP Project, and no support is guara
 If you're looking to use Closure Compiler for your project, here are some great places to get started:
 1. https://github.com/ampproject/rollup-plugin-closure-compiler
 2. https://github.com/google/closure-compiler-npm
+
+## How to build custom compilers
+
+1. Clone this repo (referred to as ACC)
+1. `cd` into ACC, and `npm install`
+   - This will create a `node_modules/google-closure-compiler-java/compiler.jar`
+1. Clone https://github.com/google/closure-compiler/ (referred to as GCC)
+1. Make your edits to GCC
+1. [Build GCC](https://github.com/google/closure-compiler/#using-bazel)
+1. Link your built GCC to ACC's `compiler.jar`
+   - `ln -s PATH_TO_GCC/bazel-bin/compiler_unshaded_deploy.jar PATH_TO_ACC/node_modules/google-closure-compiler-java/compiler.jar`
+1. Build ACC
+  - `npm run clean; npm run build`
+1. There should now be several built node modules in ACC's `/packages/`.  You need to run `npm link` on them
+  - ```for dir in `ls packages/`; do; cd dir; npm link; cd ../..; done ```
+1. In the AMP repo, you need to link these node modules:
+  - `npm link @ampproject/google-closure-compiler`
+  - `npm link google-closure-compiler-java`
+  - `npm link google-closure-compiler-java-osx` (may fail if you're not on OSX)
+  - `npm link google-closure-compiler-java-linux` (may fail if you're not on Linux)
+  - `npm link google-closure-compiler-java-windows` (may fail if you're not on Windows)

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "npmClient": "yarn",
-  "version": "20200920.1.0",
+  "version": "20201006.0.0",
   "ignoreChanges": [
     "**/compiler/**"
   ]

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "npmClient": "yarn",
-  "version": "20201006.0.0",
+  "version": "20201102.0.1",
   "ignoreChanges": [
     "**/compiler/**"
   ]

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "vinyl-sourcemaps-apply": "0.2.1"
   },
   "dependencies": {
-    "google-closure-compiler-java": "20200920.0.0"
+    "google-closure-compiler-java": "20201006.0.0"
   },
   "scripts": {
     "build": "node ./tasks/build.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "vinyl-sourcemaps-apply": "0.2.1"
   },
   "dependencies": {
-    "google-closure-compiler-java": "20201006.0.0"
+    "google-closure-compiler-java": "20201102.0.1"
   },
   "scripts": {
     "build": "node ./tasks/build.js",

--- a/packages/google-closure-compiler-java/package.json
+++ b/packages/google-closure-compiler-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler-java",
-  "version": "20201006.0.0",
+  "version": "20201102.0.1",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/google-closure-compiler-java/package.json
+++ b/packages/google-closure-compiler-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler-java",
-  "version": "20200920.1.0",
+  "version": "20201006.0.0",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/google-closure-compiler-linux/package.json
+++ b/packages/google-closure-compiler-linux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler-linux",
-  "version": "20201006.0.0",
+  "version": "20201102.0.1",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/google-closure-compiler-linux/package.json
+++ b/packages/google-closure-compiler-linux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler-linux",
-  "version": "20200920.1.0",
+  "version": "20201006.0.0",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/google-closure-compiler-osx/package.json
+++ b/packages/google-closure-compiler-osx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler-osx",
-  "version": "20201006.0.0",
+  "version": "20201102.0.1",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/google-closure-compiler-osx/package.json
+++ b/packages/google-closure-compiler-osx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler-osx",
-  "version": "20200920.1.0",
+  "version": "20201006.0.0",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/google-closure-compiler-windows/package.json
+++ b/packages/google-closure-compiler-windows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler-windows",
-  "version": "20201006.0.0",
+  "version": "20201102.0.1",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/google-closure-compiler-windows/package.json
+++ b/packages/google-closure-compiler-windows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler-windows",
-  "version": "20200920.1.0",
+  "version": "20201006.0.0",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/google-closure-compiler/package.json
+++ b/packages/google-closure-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler",
-  "version": "20201006.0.0",
+  "version": "20201102.0.1",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "bin": {
     "google-closure-compiler": "cli.js"
@@ -16,12 +16,12 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@ampproject/google-closure-compiler-java": "20201006.0.0"
+    "@ampproject/google-closure-compiler-java": "20201102.0.1"
   },
   "optionalDependencies": {
-    "@ampproject/google-closure-compiler-linux": "20201006.0.0",
-    "@ampproject/google-closure-compiler-osx": "20201006.0.0",
-    "@ampproject/google-closure-compiler-windows": "20201006.0.0"
+    "@ampproject/google-closure-compiler-linux": "20201102.0.1",
+    "@ampproject/google-closure-compiler-osx": "20201102.0.1",
+    "@ampproject/google-closure-compiler-windows": "20201102.0.1"
   },
   "scripts": {
     "test": "mocha"

--- a/packages/google-closure-compiler/package.json
+++ b/packages/google-closure-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/google-closure-compiler",
-  "version": "20200920.1.0",
+  "version": "20201006.0.0",
   "description": "Forked Closure Compiler Publishing using AMP Command Line Runner",
   "bin": {
     "google-closure-compiler": "cli.js"
@@ -16,12 +16,12 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@ampproject/google-closure-compiler-java": "20200920.1.0"
+    "@ampproject/google-closure-compiler-java": "20201006.0.0"
   },
   "optionalDependencies": {
-    "@ampproject/google-closure-compiler-linux": "20200920.1.0",
-    "@ampproject/google-closure-compiler-osx": "20200920.1.0",
-    "@ampproject/google-closure-compiler-windows": "20200920.1.0"
+    "@ampproject/google-closure-compiler-linux": "20201006.0.0",
+    "@ampproject/google-closure-compiler-osx": "20201006.0.0",
+    "@ampproject/google-closure-compiler-windows": "20201006.0.0"
   },
   "scripts": {
     "test": "mocha"

--- a/tasks/build-native-compiler.js
+++ b/tasks/build-native-compiler.js
@@ -36,7 +36,7 @@ const graalPackageSuffixMap = {
 
 const TEMP_PATH = path.resolve(__dirname, "..", "temp");
 const GRAAL_OS = graalOsMap[process.platform];
-const GRAAL_VERSION = "20.1.0";
+const GRAAL_VERSION = "20.2.0";
 const GRAAL_FOLDER = `graalvm-ce-java11-${GRAAL_OS}-amd64-${GRAAL_VERSION}`;
 const GRAAL_PACKAGE_SUFFIX = graalPackageSuffixMap[process.platform];
 const GRAAL_URL =

--- a/tasks/reflection-config.json
+++ b/tasks/reflection-config.json
@@ -154,6 +154,12 @@
     "allDeclaredFields": true
   },
   {
+    "name": "org.kohsuke.args4j.spi.PatternOptionHandler",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
     "name": "org.kohsuke.args4j.spi.PathOptionHandler",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,10 +1258,10 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-google-closure-compiler-java@20201006.0.0:
-  version "20201006.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-java/-/google-closure-compiler-java-20201006.0.0.tgz#a650d2fcac37df892be4dc34e8aa9d480b4a9748"
-  integrity sha512-22FBVYwCDxR97pNRQ1ll+YzXlaSyKHZqhDCEAPJ1q6RWhSROvV/hY/n3rZggjLj4aoi7vXU7k9KjyxtIOfdhPg==
+google-closure-compiler-java@20201102.0.1:
+  version "20201102.0.1"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-java/-/google-closure-compiler-java-20201102.0.1.tgz#15fa3e0701ee1a756168fdaf3b53fe61425b1b64"
+  integrity sha512-pXJIlyqepHhih0HCbShkAZJyViIxdyd4V7MnCUZEXLIIlygw92e2dC+5XiONDQZgRlF93BPmWCy9jr7wYoW1hQ==
 
 graceful-fs@4.X, graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.2:
   version "4.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,10 +1258,10 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-google-closure-compiler-java@20200920.0.0:
-  version "20200920.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-java/-/google-closure-compiler-java-20200920.0.0.tgz#23519b14e004f2a9eda4f5b887842ae46ad7022e"
-  integrity sha512-q8m/+QLBWrzjg5VZ2b4B628zDvbi0Gyenj9bvZQlPY7mqj68HXhe5aOfKzZO7vXgHDXMvsvI3v/1g5mPAku/5w==
+google-closure-compiler-java@20201006.0.0:
+  version "20201006.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-java/-/google-closure-compiler-java-20201006.0.0.tgz#a650d2fcac37df892be4dc34e8aa9d480b4a9748"
+  integrity sha512-22FBVYwCDxR97pNRQ1ll+YzXlaSyKHZqhDCEAPJ1q6RWhSROvV/hY/n3rZggjLj4aoi7vXU7k9KjyxtIOfdhPg==
 
 graceful-fs@4.X, graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.2:
   version "4.2.4"


### PR DESCRIPTION
The issue with AMP using the latest compiler is due to broken/incorrect sourcemaps within the amphtml project.

Bumping version after local testing with a patch to be submitted to `amphtml`.