### PR TITLE
Add `.renovaterc.json`

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,0 +1,20 @@
+{
+  "extends": ["config:base"],
+  "node": {
+    "supportPolicy": ["lts_latest"]
+  },
+  "commitMessagePrefix": "📦",
+  "packageRules": [
+    {
+      "paths": ["package.json"],
+      "depTypeList": ["devDependencies"],
+      "groupName": "Dev Dependencies"
+    },
+    {
+      "paths": ["package.json"],
+      "packagePatterns": ["^google-closure-compiler-java$"],
+      "depTypeList": ["dependencies"],
+      "groupName": "Closure Compiler"
+    }
+  ]
+}


### PR DESCRIPTION
This PR does two things:
- Enables grouped automatic renovate updates for `devDependencies` in `package.json`. This will update various testing packages.
- Enables separate automatic renovate updates for `dependencies` in `package.json`. This will update the main `google-closure-compiler-java` dependency.

Coming up: Tooling and CI updates that will result in the creation of an automatic version bump for closure updates, but not for other tooling updates. (This addresses the concern in https://github.com/ampproject/amp-closure-compiler/pull/5#issuecomment-668234227)

Closes #5