### PR TITLE
Consolidate the step to link native binaries [skip CI]

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -1,4 +1,4 @@
-name: Build, Test, and Push Native Compiler Binaries
+name: CI
 on:
   push:
     branches:
@@ -8,7 +8,7 @@ on:
       - master
 jobs:
   build-test-push:
-    if: ${{ !startsWith(github.event.head_commit.message, 'v202') && !contains(github.event.head_commit.message, 'skip CI') }}
+    if: ${{ !contains(github.event.head_commit.message, 'skip CI') }}
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
@@ -29,13 +29,7 @@ jobs:
     - name: Compile Native Binary
       run: yarn build
     - name: Link Native Binary
-      run: |
-        (yarn link --cwd packages/google-closure-compiler-osx)
-        (yarn link --cwd packages/google-closure-compiler-linux)
-        (yarn link --cwd packages/google-closure-compiler-windows)
-        (yarn link "@ampproject/google-closure-compiler-osx" --cwd packages/google-closure-compiler)
-        (yarn link "@ampproject/google-closure-compiler-linux" --cwd packages/google-closure-compiler)
-        (yarn link "@ampproject/google-closure-compiler-windows" --cwd packages/google-closure-compiler)
+      run: yarn link-native
     - name: Test Changes
       run: yarn test
     - name: Push Native Binary for ${{ matrix.platform }}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "scripts": {
     "build": "node ./tasks/build.js",
     "test": "node ./tasks/test.js",
+    "link-native": "node ./tasks/link-native.js",
     "clean": "node ./tasks/clean.js"
   }
 }

--- a/tasks/link-native.js
+++ b/tasks/link-native.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"use strict";
+
+const { exec } = require("./exec.js");
+const { getOsName } = require('./utils.js');
+
+/**
+ * Link native binary for the current OS
+ **/
+(async function () {
+  exec(`yarn link --cwd packages/google-closure-compiler-${getOsName()}`);
+  exec(`yarn link "@ampproject/google-closure-compiler-${getOsName()}" --cwd packages/google-closure-compiler`);
+})();
+
+


### PR DESCRIPTION
**PR highlights:**
- Instead of trying to link all platforms all the time, do it dynamically per-platform.
- Clean up duplicate naming of GH actions workflow
- Remove no longer necessary condition for running GH Actions build