### PR TITLE
Enable Prettier auto-formatting for the repo [skip CI]

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -15,25 +15,25 @@ jobs:
         node-version: [12.x]
     runs-on: ${{ matrix.platform }}
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v2
-    - name: Set up Windows Dev Environment (skipped on Linux and macOS)
-      uses: seanmiddleditch/gha-setup-vsdevenv@master
-      if: ${{ matrix.platform == 'windows-latest' }}
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2-beta
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install Dependencies
-      run: npm ci
-    - name: Compile Native Binary
-      run: npm run build
-    - name: Link Native Binary
-      run: npm run link-native
-    - name: Test Changes
-      run: npm run test
-    - name: Push Native Binary for ${{ matrix.platform }}
-      run: node ./tasks/push-binary.js
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Set up Windows Dev Environment (skipped on Linux and macOS)
+        uses: seanmiddleditch/gha-setup-vsdevenv@master
+        if: ${{ matrix.platform == 'windows-latest' }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Dependencies
+        run: npm ci
+      - name: Compile Native Binary
+        run: npm run build
+      - name: Link Native Binary
+        run: npm run link-native
+      - name: Test Changes
+        run: npm run test
+      - name: Push Native Binary for ${{ matrix.platform }}
+        run: node ./tasks/push-binary.js
   update-versions:
     needs: build-test-push
     runs-on: ubuntu-latest

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+packages/google-closure-compiler/
+third_party/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,26 @@
+{
+  "bracketSpacing": false,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "quoteProps": "preserve",
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "parser": "markdown",
+        "embeddedLanguageFormatting": "off",
+        "tabWidth": 4
+      }
+    },
+    {
+      "files": [".prettierrc", ".renovaterc.json", "*.json"],
+      "options": {"parser": "json"}
+    },
+    {
+      "files": [
+        ".github/workflows/build-test-push.yml"
+      ],
+      "options": {"parser": "yaml"}
+    }
+  ]
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -17,9 +17,7 @@
       "options": {"parser": "json"}
     },
     {
-      "files": [
-        ".github/workflows/build-test-push.yml"
-      ],
+      "files": [".github/workflows/build-test-push.yml"],
       "options": {"parser": "yaml"}
     }
   ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "files.associations": {
+    // Enable JSON auto-formatting for these files.
+    ".prettierrc": "json",
+    ".renovaterc.json": "json",
+    ".vscode/settings.json": "json",
+
+    // Enable YAML auto-formatting for these files.
+    ".github/workflows/build-test-push.yml": "yaml",
+  },
+
+  // Auto-fix files with Prettier using the repo's custom settings.
+  "[javascript]": {"editor.formatOnSave": true},
+  "[yaml]": {"editor.formatOnSave": true},
+  "[json]": {"editor.formatOnSave": true},
+  "[markdown]": {"editor.formatOnSave": true}
+}

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -7,11 +7,13 @@ git pull
 ```
 
 Run tests locally and make sure they pass.
+
 ```
 npm run test
 ```
 
 Publish a new version for each package. (Use `--dry-run` to preview results without actually publishing.)
+
 ```
 for package in `ls packages/`;
 do npm publish --access public --otp <OTP> packages/$package [--dry-run];

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ You can inspect them under the `src` directory.
 This is not intended to be used outside the AMP Project, and no support is guaranteed.
 
 If you're looking to use Closure Compiler for your project, here are some great places to get started:
+
 1. https://github.com/ampproject/rollup-plugin-closure-compiler
 2. https://github.com/google/closure-compiler-npm
 
@@ -36,7 +37,7 @@ If you're looking to use Closure Compiler for your project, here are some great 
     npm run clean
     npm run build
     ```
-1. There should now be several built node modules in `amp-closure-compiler`'s `/packages/` directory.  You need to link them to them
+1. There should now be several built node modules in `amp-closure-compiler`'s `/packages/` directory. You need to link them to them
     ```sh
     for dir in `ls packages/`;
     do;

--- a/tasks/build-java-compiler.js
+++ b/tasks/build-java-compiler.js
@@ -14,13 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-"use strict";
+'use strict';
 
-const kleur = require("kleur");
-const { promises: fs } = require("fs");
-const { platform } = require('os');
-const { getOsName } = require('./utils.js');
-const { getOutput } = require('./exec.js');
+const kleur = require('kleur');
+const {promises: fs} = require('fs');
+const {platform} = require('os');
+const {getOsName} = require('./utils.js');
+const {getOutput} = require('./exec.js');
 
 /**
  * Copy the newly built compiler and the contrib folder to the applicable packages.
@@ -28,11 +28,11 @@ const { getOutput } = require('./exec.js');
  * @return {!Promise<undefined>}
  */
 function copyCompilerBinaries() {
-  const compiledJavaBinaryPath = "./dist/compiler.jar";
+  const compiledJavaBinaryPath = './dist/compiler.jar';
   return Promise.all([
     fs.copyFile(
       compiledJavaBinaryPath,
-      "./packages/google-closure-compiler-java/compiler.jar"
+      './packages/google-closure-compiler-java/compiler.jar'
     ),
     fs.copyFile(
       compiledJavaBinaryPath,
@@ -48,31 +48,34 @@ function copyCompilerBinaries() {
 (async function () {
   const compiledJarDir = 'dist';
   const buildFile = 'tasks/build.xml';
-  const antExecutable = getOsName() == 'windows' ? 'third_party\\ant\\bin\\ant.bat' : './third_party/ant/bin/ant';
+  const antExecutable =
+    getOsName() == 'windows'
+      ? 'third_party\\ant\\bin\\ant.bat'
+      : './third_party/ant/bin/ant';
   const generateCmd = `${antExecutable} -buildfile ${buildFile} -Ddist.dir ${compiledJarDir} jar`;
   console.log(
-    kleur.green("INFO: ") +
-      "Generating custom closure compiler by running " +
+    kleur.green('INFO: ') +
+      'Generating custom closure compiler by running ' +
       kleur.cyan(generateCmd)
   );
   const result = getOutput(generateCmd, {stdio: 'inherit'});
   if (0 !== result.status) {
     console.log(
-      kleur.red("ERROR: ") +
-        "Could not generate custom closure compiler " +
+      kleur.red('ERROR: ') +
+        'Could not generate custom closure compiler ' +
         kleur.cyan(`${compiledJarDir}/compiler.jar`)
     );
     console.error(kleur.red(result.stdout), kleur.red(result.stderr));
     process.exit(1);
   }
   console.log(
-    kleur.green("SUCCESS: ") +
-      "Generated custom closure compiler " +
+    kleur.green('SUCCESS: ') +
+      'Generated custom closure compiler ' +
       kleur.cyan(`${compiledJarDir}/compiler.jar`)
   );
 
   await copyCompilerBinaries();
   console.log(
-    kleur.green("SUCCESS: ") + "Copied custom closure compiler to packages"
+    kleur.green('SUCCESS: ') + 'Copied custom closure compiler to packages'
   );
 })();

--- a/tasks/build-native-compiler.js
+++ b/tasks/build-native-compiler.js
@@ -14,29 +14,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-"use strict";
+'use strict';
 
 // Note: We download graal since it's 800MB+ of disk space per platform.
-const fs = require("fs");
-const path = require("path");
-const { execOrDie } = require("./exec.js");
-const { getOsName } = require('./utils.js');
+const fs = require('fs');
+const path = require('path');
+const {execOrDie} = require('./exec.js');
+const {getOsName} = require('./utils.js');
 
 const graalOsMap = {
   linux: 'linux',
   darwin: 'darwin',
   win32: 'windows',
-}
+};
 
 const graalPackageSuffixMap = {
   linux: 'tar.gz',
   darwin: 'tar.gz',
   win32: 'zip',
-}
+};
 
-const TEMP_PATH = path.resolve(__dirname, "..", "temp");
+const TEMP_PATH = path.resolve(__dirname, '..', 'temp');
 const GRAAL_OS = graalOsMap[process.platform];
-const GRAAL_VERSION = "20.2.0";
+const GRAAL_VERSION = '20.2.0';
 const GRAAL_FOLDER = `graalvm-ce-java11-${GRAAL_OS}-amd64-${GRAAL_VERSION}`;
 const GRAAL_PACKAGE_SUFFIX = graalPackageSuffixMap[process.platform];
 const GRAAL_URL =
@@ -44,27 +44,27 @@ const GRAAL_URL =
   `https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${GRAAL_VERSION}/${GRAAL_FOLDER}.${GRAAL_PACKAGE_SUFFIX}`;
 
 const NATIVE_IMAGE_BUILD_ARGS = [
-  "-H:+JNI",
-  "--no-server",
-  "-H:+ReportUnsupportedElementsAtRuntime",
-  "-H:IncludeResourceBundles=com.google.javascript.rhino.Messages",
-  "-H:IncludeResourceBundles=org.kohsuke.args4j.Messages",
-  "-H:IncludeResourceBundles=org.kohsuke.args4j.spi.Messages",
-  "-H:IncludeResourceBundles=com.google.javascript.jscomp.parsing.ParserConfig",
+  '-H:+JNI',
+  '--no-server',
+  '-H:+ReportUnsupportedElementsAtRuntime',
+  '-H:IncludeResourceBundles=com.google.javascript.rhino.Messages',
+  '-H:IncludeResourceBundles=org.kohsuke.args4j.Messages',
+  '-H:IncludeResourceBundles=org.kohsuke.args4j.spi.Messages',
+  '-H:IncludeResourceBundles=com.google.javascript.jscomp.parsing.ParserConfig',
   `-H:ReflectionConfigurationFiles=${path.resolve(
     __dirname,
-    "reflection-config.json"
+    'reflection-config.json'
   )}`,
-  "-H:IncludeResources=\"(externs.zip)|(.*(js|txt))\"",
-  "-H:+ReportExceptionStackTraces",
-  "--initialize-at-build-time",
-  "-jar",
-  path.resolve(process.cwd(), "dist", "compiler.jar"),
+  '-H:IncludeResources="(externs.zip)|(.*(js|txt))"',
+  '-H:+ReportExceptionStackTraces',
+  '--initialize-at-build-time',
+  '-jar',
+  path.resolve(process.cwd(), 'dist', 'compiler.jar'),
 ].join(' ');
 
 // This script should catch and handle all rejected promises.
 // If it ever fails to do so, report that and exit immediately.
-process.on("unhandledRejection", (error) => {
+process.on('unhandledRejection', (error) => {
   console.error(error);
   process.exit(1);
 });
@@ -82,16 +82,16 @@ process.on("unhandledRejection", (error) => {
   const GRAAL_ARCHIVE_FILE = `${GRAAL_FOLDER}.${GRAAL_PACKAGE_SUFFIX}`;
   // Build the compiler native image.
   let pathParts = [TEMP_PATH, `graalvm-ce-java11-${GRAAL_VERSION}`];
-  if (GRAAL_OS === "darwin") {
-    pathParts.push("Contents", "Home", "bin");
+  if (GRAAL_OS === 'darwin') {
+    pathParts.push('Contents', 'Home', 'bin');
   } else {
-    pathParts.push("bin");
+    pathParts.push('bin');
   }
   const GRAAL_BIN_FOLDER = path.resolve.apply(null, pathParts);
   if (!fs.existsSync(path.resolve(TEMP_PATH, GRAAL_FOLDER))) {
     const GRAAL_GU_PATH = path.resolve(
       GRAAL_BIN_FOLDER,
-      `gu${GRAAL_OS === "windows" ? ".cmd" : ""}`
+      `gu${GRAAL_OS === 'windows' ? '.cmd' : ''}`
     );
     buildSteps = buildSteps
       .then(() => {
@@ -100,13 +100,13 @@ process.on("unhandledRejection", (error) => {
           console.log(`Downloading graal from ${GRAAL_URL}`);
           execOrDie(
             `curl --fail --show-error --location --progress-bar --output ${GRAAL_ARCHIVE_FILE} ${GRAAL_URL}`,
-            { cwd: TEMP_PATH }
+            {cwd: TEMP_PATH}
           );
         }
       })
       .then(() => {
         console.log(`Extracting ${GRAAL_ARCHIVE_FILE}`);
-        if (GRAAL_PACKAGE_SUFFIX === "tar.gz") {
+        if (GRAAL_PACKAGE_SUFFIX === 'tar.gz') {
           execOrDie(`tar -xzf ${GRAAL_ARCHIVE_FILE}`, {cwd: TEMP_PATH});
         } else {
           execOrDie(`7z x -y ${GRAAL_ARCHIVE_FILE}`, {cwd: TEMP_PATH});
@@ -121,24 +121,38 @@ process.on("unhandledRejection", (error) => {
   // Build the compiler native image.
   const GRAAL_NATIVE_IMAGE_PATH = path.resolve(
     GRAAL_BIN_FOLDER,
-    `native-image${GRAAL_OS === "windows" ? ".cmd" : ""}`
+    `native-image${GRAAL_OS === 'windows' ? '.cmd' : ''}`
   );
 
-  const packageDir = path.join('packages', `google-closure-compiler-${getOsName()}`);
+  const packageDir = path.join(
+    'packages',
+    `google-closure-compiler-${getOsName()}`
+  );
 
   return buildSteps
     .then(() => {
       console.log(`Testing native image:`);
-      fs.writeFileSync(path.join(packageDir, 'Foo.java'), 'public class Foo { public static void main(String[] args){ System.out.println("Hello amp-closure-compiler!"); } }\n');
-      execOrDie(GRAAL_OS === "windows" ? 'type Foo.java' : 'cat Foo.java', {cwd: packageDir})
+      fs.writeFileSync(
+        path.join(packageDir, 'Foo.java'),
+        'public class Foo { public static void main(String[] args){ System.out.println("Hello amp-closure-compiler!"); } }\n'
+      );
+      execOrDie(GRAAL_OS === 'windows' ? 'type Foo.java' : 'cat Foo.java', {
+        cwd: packageDir,
+      });
       execOrDie('javac -version', {cwd: packageDir});
       execOrDie('javac Foo.java', {cwd: packageDir});
       execOrDie(`cd ${packageDir} && ${GRAAL_NATIVE_IMAGE_PATH} Foo`);
-      execOrDie(`${GRAAL_OS === "windows" ? 'dir' : 'ls -la'} ${packageDir}`);
-      execOrDie(path.join(packageDir, GRAAL_OS === "windows" ? 'foo.exe' : 'foo'));
+      execOrDie(`${GRAAL_OS === 'windows' ? 'dir' : 'ls -la'} ${packageDir}`);
+      execOrDie(
+        path.join(packageDir, GRAAL_OS === 'windows' ? 'foo.exe' : 'foo')
+      );
     })
     .then(() => {
-      console.log(`Building native image: ${GRAAL_NATIVE_IMAGE_PATH} ${NATIVE_IMAGE_BUILD_ARGS}`);
-      execOrDie(`cd ${packageDir} && ${GRAAL_NATIVE_IMAGE_PATH} ${NATIVE_IMAGE_BUILD_ARGS}`);
+      console.log(
+        `Building native image: ${GRAAL_NATIVE_IMAGE_PATH} ${NATIVE_IMAGE_BUILD_ARGS}`
+      );
+      execOrDie(
+        `cd ${packageDir} && ${GRAAL_NATIVE_IMAGE_PATH} ${NATIVE_IMAGE_BUILD_ARGS}`
+      );
     });
 })();

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -14,9 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-"use strict";
+'use strict';
 
-const { execOrDie } = require("./exec.js");
+const {execOrDie} = require('./exec.js');
 
 /**
  * Run the build commands and fail the script if any of them failed

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -14,10 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-"use strict";
+'use strict';
 
 const del = require('del');
-const { exec } = require("./exec.js");
+const {exec} = require('./exec.js');
 
 /**
  * Remove all build artifacts and OS restrictions
@@ -34,8 +34,6 @@ const { exec } = require("./exec.js");
     './packages/google-closure-compiler-windows/compiler.jar',
     './packages/google-closure-compiler-windows/compiler',
   ];
-  await del(pathsToDelete)
+  await del(pathsToDelete);
   exec('node ./tasks/remove-os-restrictions.js');
 })();
-
-

--- a/tasks/link-native.js
+++ b/tasks/link-native.js
@@ -14,17 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-"use strict";
+'use strict';
 
-const { exec } = require("./exec.js");
-const { getOsName } = require('./utils.js');
+const {exec} = require('./exec.js');
+const {getOsName} = require('./utils.js');
 
 /**
  * Link native binary for the current OS
  **/
 (async function () {
   exec(`npm link --prefix packages/google-closure-compiler-${getOsName()}`);
-  exec(`npm link "@ampproject/google-closure-compiler-${getOsName()}" --prefix packages/google-closure-compiler`);
+  exec(
+    `npm link "@ampproject/google-closure-compiler-${getOsName()}" --prefix packages/google-closure-compiler`
+  );
 })();
-
-

--- a/tasks/push-binary.js
+++ b/tasks/push-binary.js
@@ -14,11 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-"use strict";
+'use strict';
 
 const path = require('path');
-const { exec, execOrDie } = require('./exec.js');
-const { getOsName, pushPendingCommits } = require('./utils.js');
+const {exec, execOrDie} = require('./exec.js');
+const {getOsName, pushPendingCommits} = require('./utils.js');
 
 /**
  * Push the compiler binary built on this OS after syncing to origin. Also push
@@ -26,10 +26,20 @@ const { getOsName, pushPendingCommits } = require('./utils.js');
  **/
 async function main() {
   const osName = getOsName();
-  const javaCompiler = path.join('packages', 'google-closure-compiler-java', 'compiler.jar')
-  const nativeCompiler = path.join('packages', `google-closure-compiler-${osName}`, osName == 'windows' ? 'compiler.exe' : 'compiler')
+  const javaCompiler = path.join(
+    'packages',
+    'google-closure-compiler-java',
+    'compiler.jar'
+  );
+  const nativeCompiler = path.join(
+    'packages',
+    `google-closure-compiler-${osName}`,
+    osName == 'windows' ? 'compiler.exe' : 'compiler'
+  );
   execOrDie(`git config --global user.name "${process.env.GITHUB_ACTOR}"`);
-  execOrDie(`git config --global user.email "${process.env.GITHUB_ACTOR}@users.noreply.github.com"`);
+  execOrDie(
+    `git config --global user.email "${process.env.GITHUB_ACTOR}@users.noreply.github.com"`
+  );
   // It's sufficient to update the Java compiler just once
   if (osName == 'linux') {
     execOrDie(`git add ${javaCompiler}`);

--- a/tasks/reflection-config.json
+++ b/tasks/reflection-config.json
@@ -1,77 +1,77 @@
 [
   {
-    "name" : "com.google.javascript.jscomp.CommandLineRunner$Flags",
-    "allDeclaredFields" : true
+    "name": "com.google.javascript.jscomp.CommandLineRunner$Flags",
+    "allDeclaredFields": true
   },
   {
-    "name" : "com.google.javascript.jscomp.CommandLineRunner$Flags$BooleanOptionHandler",
-    "allDeclaredConstructors" : true,
+    "name": "com.google.javascript.jscomp.CommandLineRunner$Flags$BooleanOptionHandler",
+    "allDeclaredConstructors": true,
     "allDeclaredMethods": true
   },
   {
-    "name" : "com.google.javascript.jscomp.CommandLineRunner$Flags$WarningGuardErrorOptionHandler",
-    "allDeclaredConstructors" : true,
+    "name": "com.google.javascript.jscomp.CommandLineRunner$Flags$WarningGuardErrorOptionHandler",
+    "allDeclaredConstructors": true,
     "allDeclaredMethods": true
   },
   {
-    "name" : "com.google.javascript.jscomp.CommandLineRunner$Flags$WarningGuardWarningOptionHandler",
-    "allDeclaredConstructors" : true,
+    "name": "com.google.javascript.jscomp.CommandLineRunner$Flags$WarningGuardWarningOptionHandler",
+    "allDeclaredConstructors": true,
     "allDeclaredMethods": true
   },
   {
-    "name" : "com.google.javascript.jscomp.CommandLineRunner$Flags$WarningGuardOffOptionHandler",
-    "allDeclaredConstructors" : true,
+    "name": "com.google.javascript.jscomp.CommandLineRunner$Flags$WarningGuardOffOptionHandler",
+    "allDeclaredConstructors": true,
     "allDeclaredMethods": true
   },
   {
-    "name" : "com.google.javascript.jscomp.CommandLineRunner$Flags$JsOptionHandler",
-    "allDeclaredConstructors" : true,
+    "name": "com.google.javascript.jscomp.CommandLineRunner$Flags$JsOptionHandler",
+    "allDeclaredConstructors": true,
     "allDeclaredMethods": true
   },
   {
-    "name" : "com.google.javascript.jscomp.CommandLineRunner$Flags$JsZipOptionHandler",
-    "allDeclaredConstructors" : true,
+    "name": "com.google.javascript.jscomp.CommandLineRunner$Flags$JsZipOptionHandler",
+    "allDeclaredConstructors": true,
     "allDeclaredMethods": true
   },
   {
-    "name" : "com.google.javascript.jscomp.AbstractCommandLineRunner$JsonFileSpec",
-    "allDeclaredConstructors" : true,
+    "name": "com.google.javascript.jscomp.AbstractCommandLineRunner$JsonFileSpec",
+    "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
     "allDeclaredFields": true,
-    "fields" : [
-      { "name" : "src", "allowWrite" : true },
-      { "name" : "path", "allowWrite" : true },
-      { "name" : "sourceMap", "allowWrite" : true },
-      { "name" : "webpackId", "allowWrite" : true }
+    "fields": [
+      {"name": "src", "allowWrite": true},
+      {"name": "path", "allowWrite": true},
+      {"name": "sourceMap", "allowWrite": true},
+      {"name": "webpackId", "allowWrite": true}
     ]
   },
   {
-    "name" : "org.kohsuke.args4j.CmdLineParser",
-    "allDeclaredConstructors" : true,
+    "name": "org.kohsuke.args4j.CmdLineParser",
+    "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
     "allDeclaredFields": true
   },
   {
-    "name" : "org.kohsuke.args4j.Option",
-    "allDeclaredConstructors" : true,
+    "name": "org.kohsuke.args4j.Option",
+    "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
     "allDeclaredFields": true
   },
   {
-    "name" : "org.kohsuke.args4j.OptionDef",
-    "allDeclaredConstructors" : true,
+    "name": "org.kohsuke.args4j.OptionDef",
+    "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
     "allDeclaredFields": true
   },
   {
-    "name" : "org.kohsuke.args4j.spi.FieldSetter",
-    "allDeclaredConstructors" : true,
+    "name": "org.kohsuke.args4j.spi.FieldSetter",
+    "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
     "allDeclaredFields": true
   },
   {
-    "name" : "org.kohsuke.args4j.spi.Setter",
-    "allDeclaredConstructors" : true,
+    "name": "org.kohsuke.args4j.spi.Setter",
+    "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
     "allDeclaredFields": true
   },
@@ -190,114 +190,114 @@
     "allDeclaredFields": true
   },
   {
-    "name" : "com.google.javascript.jscomp.ConformanceConfig",
-    "allDeclaredMethods" : true,
-    "allDeclaredFields" : true,
-    "allPublicMethods" : true,
-    "allPublicFields" : true
+    "name": "com.google.javascript.jscomp.ConformanceConfig",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true,
+    "allPublicFields": true
   },
   {
-    "name" : "com.google.javascript.jscomp.ConformanceConfig$Builder",
-    "allDeclaredMethods" : true,
-    "allDeclaredFields" : true,
-    "allPublicMethods" : true,
-    "allPublicFields" : true
+    "name": "com.google.javascript.jscomp.ConformanceConfig$Builder",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true,
+    "allPublicFields": true
   },
   {
-    "name" : "com.google.javascript.jscomp.ConformanceRules",
-    "allDeclaredMethods" : true,
-    "allDeclaredFields" : true,
-    "allPublicMethods" : true,
-    "allPublicFields" : true
+    "name": "com.google.javascript.jscomp.ConformanceRules",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true,
+    "allPublicFields": true
   },
   {
-    "name" : "com.google.javascript.jscomp.ConformanceRules$BanCreateDom",
-    "methods" : [ { "name" : "<init>" } ],
-    "allDeclaredMethods" : true,
-    "allDeclaredFields" : true,
-    "allPublicMethods" : true,
-    "allPublicFields" : true
+    "name": "com.google.javascript.jscomp.ConformanceRules$BanCreateDom",
+    "methods": [{"name": "<init>"}],
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true,
+    "allPublicFields": true
   },
   {
-    "name" : "com.google.javascript.jscomp.ConformanceRules$BanCreateElement",
-    "methods" : [ { "name" : "<init>" } ],
-    "allDeclaredMethods" : true,
-    "allDeclaredFields" : true,
-    "allPublicMethods" : true,
-    "allPublicFields" : true
+    "name": "com.google.javascript.jscomp.ConformanceRules$BanCreateElement",
+    "methods": [{"name": "<init>"}],
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true,
+    "allPublicFields": true
   },
   {
-    "name" : "com.google.javascript.jscomp.ConformanceRules$BanExpose",
-    "methods" : [ { "name" : "<init>" } ],
-    "allDeclaredMethods" : true,
-    "allDeclaredFields" : true,
-    "allPublicMethods" : true,
-    "allPublicFields" : true
+    "name": "com.google.javascript.jscomp.ConformanceRules$BanExpose",
+    "methods": [{"name": "<init>"}],
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true,
+    "allPublicFields": true
   },
   {
-    "name" : "com.google.javascript.jscomp.ConformanceRules$BanGlobalVars",
-    "methods" : [ { "name" : "<init>" } ],
-    "allDeclaredMethods" : true,
-    "allDeclaredFields" : true,
-    "allPublicMethods" : true,
-    "allPublicFields" : true
+    "name": "com.google.javascript.jscomp.ConformanceRules$BanGlobalVars",
+    "methods": [{"name": "<init>"}],
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true,
+    "allPublicFields": true
   },
   {
-    "name" : "com.google.javascript.jscomp.ConformanceRules$BanThrowOfNonErrorTypes",
-    "methods" : [ { "name" : "<init>" } ],
-    "allDeclaredMethods" : true,
-    "allDeclaredFields" : true,
-    "allPublicMethods" : true,
-    "allPublicFields" : true
+    "name": "com.google.javascript.jscomp.ConformanceRules$BanThrowOfNonErrorTypes",
+    "methods": [{"name": "<init>"}],
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true,
+    "allPublicFields": true
   },
   {
-    "name" : "com.google.javascript.jscomp.ConformanceRules$BanUnknownThis",
-    "methods" : [ { "name" : "<init>" } ],
-    "allDeclaredMethods" : true,
-    "allDeclaredFields" : true,
-    "allPublicMethods" : true,
-    "allPublicFields" : true
+    "name": "com.google.javascript.jscomp.ConformanceRules$BanUnknownThis",
+    "methods": [{"name": "<init>"}],
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true,
+    "allPublicFields": true
   },
   {
-    "name" : "com.google.javascript.jscomp.Requirement",
-    "allDeclaredMethods" : true,
-    "allDeclaredFields" : true,
-    "allPublicMethods" : true,
-    "allPublicFields" : true
+    "name": "com.google.javascript.jscomp.Requirement",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true,
+    "allPublicFields": true
   },
   {
-    "name" : "com.google.javascript.jscomp.Requirement$Builder",
-    "allDeclaredMethods" : true,
-    "allDeclaredFields" : true,
-    "allPublicMethods" : true,
-    "allPublicFields" : true
+    "name": "com.google.javascript.jscomp.Requirement$Builder",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true,
+    "allPublicFields": true
   },
   {
-    "name" : "com.google.javascript.jscomp.Requirement$WhitelistEntry",
-    "allDeclaredMethods" : true,
-    "allDeclaredFields" : true,
-    "allPublicMethods" : true,
-    "allPublicFields" : true
+    "name": "com.google.javascript.jscomp.Requirement$WhitelistEntry",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true,
+    "allPublicFields": true
   },
   {
-    "name" : "com.google.javascript.jscomp.Requirement$Type",
-    "allDeclaredMethods" : true,
-    "allDeclaredFields" : true,
-    "allPublicMethods" : true,
-    "allPublicFields" : true
+    "name": "com.google.javascript.jscomp.Requirement$Type",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true,
+    "allPublicFields": true
   },
   {
-    "name" : "com.google.javascript.jscomp.Requirement$TypeMatchingStrategy",
-    "allDeclaredMethods" : true,
-    "allDeclaredFields" : true,
-    "allPublicMethods" : true,
-    "allPublicFields" : true
+    "name": "com.google.javascript.jscomp.Requirement$TypeMatchingStrategy",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true,
+    "allPublicFields": true
   },
   {
-    "name" : "com.google.javascript.jscomp.Requirement$Severity",
-    "allDeclaredMethods" : true,
-    "allDeclaredFields" : true,
-    "allPublicMethods" : true,
-    "allPublicFields" : true
+    "name": "com.google.javascript.jscomp.Requirement$Severity",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true,
+    "allPublicFields": true
   }
 ]

--- a/tasks/run-command.js
+++ b/tasks/run-command.js
@@ -41,9 +41,13 @@ function runCommand(cmd, args, spawnOpts) {
     args = commandParts.slice(1);
   }
   // child process should inherit stdin/out/err from this process unless spawnOpts says otherwise
-  spawnOpts = Object.assign({}, {
-    stdio: 'inherit'
-  }, spawnOpts);
+  spawnOpts = Object.assign(
+    {},
+    {
+      stdio: 'inherit',
+    },
+    spawnOpts
+  );
 
   let externalProcess;
   const promise = new Promise((resolve, reject) => {
@@ -51,7 +55,7 @@ function runCommand(cmd, args, spawnOpts) {
     let stderr = '';
 
     externalProcess = spawn(cmd, args, spawnOpts);
-    externalProcess.on('error', err => {
+    externalProcess.on('error', (err) => {
       if (!err) {
         err = new Error(stderr || 'external process error');
       } else if (!(err instanceof Error)) {
@@ -62,7 +66,7 @@ function runCommand(cmd, args, spawnOpts) {
       err.exitCode = 1;
       reject(err);
     });
-    externalProcess.on('close', exitCode => {
+    externalProcess.on('close', (exitCode) => {
       if (exitCode != 0) {
         const err = new Error(`non-zero exit code ${exitCode}`);
         err.stdout = stdout;
@@ -73,12 +77,12 @@ function runCommand(cmd, args, spawnOpts) {
       resolve({stdout, stderr, exitCode});
     });
     if (externalProcess.stdout) {
-      externalProcess.stdout.on('data', data => {
+      externalProcess.stdout.on('data', (data) => {
         stdout += data.toString();
       });
     }
     if (externalProcess.stderr) {
-      externalProcess.stderr.on('data', data => {
+      externalProcess.stderr.on('data', (data) => {
         stderr += data.toString();
       });
     }

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -14,19 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-"use strict";
+'use strict';
 
 const fs = require('fs');
 const path = require('path');
 const kleur = require('kleur');
-const { execOrDie } = require('./exec.js');
-const { getOsName } = require('./utils.js');
-const { spawn } = require('child_process');
+const {execOrDie} = require('./exec.js');
+const {getOsName} = require('./utils.js');
+const {spawn} = require('child_process');
 
 function runJavaTest() {
   const javaPath = require('../packages/google-closure-compiler-java/');
   if (fs.existsSync(javaPath)) {
-    process.stdout.write(`  ${kleur.green('✓')} ${kleur.dim('compiler jar exists')}\n`);
+    process.stdout.write(
+      `  ${kleur.green('✓')} ${kleur.dim('compiler jar exists')}\n`
+    );
   } else {
     process.stdout.write(`  ${kleur.red('compiler jar does not exist')}\n`);
     process.exitCode = 1;
@@ -36,47 +38,57 @@ function runJavaTest() {
 function runNativeTest() {
   const nativeImagePath = require(`../packages/google-closure-compiler-${getOsName()}/`);
   if (fs.existsSync(nativeImagePath)) {
-    process.stdout.write(`  ${kleur.green('✓')} ${kleur.dim('compiler binary exists')}\n`);
-    new Promise(
-        (resolve, reject) => {
-          const compilerTest = spawn(
-            nativeImagePath,
-              ['--version'],
-              {stdio: 'inherit'});
-          compilerTest.on('error', err => {
-            reject(err);
-          });
-          compilerTest.on('close', exitCode => {
-            if (exitCode != 0) {
-              return reject('non zero exit code');
-            }
-            process.stdout.write(
-                `  ${kleur.green('✓')} ${kleur.dim('compiler version successfully reported')}\n`);
-            resolve();
-          });
-        })
-        .then(() => new Promise((resolve, reject) => {
-          const compilerTest = spawn(
-            nativeImagePath,
-              ['--help'],
-              {stdio: 'inherit'});
-          compilerTest.on('error', err => {
-            reject(err);
-          });
-          compilerTest.on('close', exitCode => {
-            if (exitCode != 0) {
-              return reject('non zero exit code');
-            }
-            process.stdout.write(
-                `  ${kleur.green('✓')} ${kleur.dim('compiler help successfully reported')}\n`);
-            resolve();
-          });
-        }))
-        .catch(err => {
-          process.stderr.write((err || '').toString() + '\n');
-          process.stdout.write(`  ${kleur.red('compiler execution tests failed')}\n`);
-          process.exitCode = 1;
-        });
+    process.stdout.write(
+      `  ${kleur.green('✓')} ${kleur.dim('compiler binary exists')}\n`
+    );
+    new Promise((resolve, reject) => {
+      const compilerTest = spawn(nativeImagePath, ['--version'], {
+        stdio: 'inherit',
+      });
+      compilerTest.on('error', (err) => {
+        reject(err);
+      });
+      compilerTest.on('close', (exitCode) => {
+        if (exitCode != 0) {
+          return reject('non zero exit code');
+        }
+        process.stdout.write(
+          `  ${kleur.green('✓')} ${kleur.dim(
+            'compiler version successfully reported'
+          )}\n`
+        );
+        resolve();
+      });
+    })
+      .then(
+        () =>
+          new Promise((resolve, reject) => {
+            const compilerTest = spawn(nativeImagePath, ['--help'], {
+              stdio: 'inherit',
+            });
+            compilerTest.on('error', (err) => {
+              reject(err);
+            });
+            compilerTest.on('close', (exitCode) => {
+              if (exitCode != 0) {
+                return reject('non zero exit code');
+              }
+              process.stdout.write(
+                `  ${kleur.green('✓')} ${kleur.dim(
+                  'compiler help successfully reported'
+                )}\n`
+              );
+              resolve();
+            });
+          })
+      )
+      .catch((err) => {
+        process.stderr.write((err || '').toString() + '\n');
+        process.stdout.write(
+          `  ${kleur.red('compiler execution tests failed')}\n`
+        );
+        process.exitCode = 1;
+      });
   } else {
     process.stdout.write(`  ${kleur.red('compiler binary does not exist')}\n`);
     process.exitCode = 1;

--- a/tasks/utils.js
+++ b/tasks/utils.js
@@ -14,9 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-"use strict";
+'use strict';
 
-const { exec, execOrDie } = require('./exec.js');
+const {exec, execOrDie} = require('./exec.js');
 
 /**
  * Mapping from process.platform to the OS name / directory.
@@ -25,7 +25,7 @@ const platformOsMap = {
   linux: 'linux',
   darwin: 'osx',
   win32: 'windows',
-}
+};
 
 /**
  * Returns the Closure OS name for the corresponding platform.
@@ -41,10 +41,10 @@ function getOsName() {
  */
 function pushPendingCommits() {
   if (process.env.GITHUB_EVENT_NAME == 'pull_request') {
-    console.log('Verifying files in new commit(s)...')
+    console.log('Verifying files in new commit(s)...');
     execOrDie(`git diff --stat ${process.env.GITHUB_SHA}..HEAD`);
   } else if (process.env.GITHUB_EVENT_NAME == 'push') {
-    console.log('Syncing to origin and pushing commit(s)...')
+    console.log('Syncing to origin and pushing commit(s)...');
     let retries = 3;
     const delaySec = 10;
     const pushCommits = () => {
@@ -52,13 +52,13 @@ function pushPendingCommits() {
         console.log('Could not push commit(s) to origin.');
         process.exitCode = 1;
         return;
-      };
+      }
       if (exec('git pull origin --rebase && git push').status != 0) {
         --retries;
-        console.log(`Push failed. Retrying in ${delaySec} seconds...`)
+        console.log(`Push failed. Retrying in ${delaySec} seconds...`);
         setTimeout(pushCommits, delaySec * 1000);
       }
-    }
+    };
     pushCommits();
   }
 }
@@ -69,10 +69,10 @@ function pushPendingCommits() {
  */
 function pushPendingTags() {
   if (process.env.GITHUB_EVENT_NAME == 'pull_request') {
-    console.log('Verifying tags(s)...')
+    console.log('Verifying tags(s)...');
     execOrDie('git tag --list');
   } else if (process.env.GITHUB_EVENT_NAME == 'push') {
-    console.log('Syncing to origin and pushing tag(s)...')
+    console.log('Syncing to origin and pushing tag(s)...');
     let retries = 3;
     const delaySec = 10;
     const pushTags = () => {
@@ -80,20 +80,21 @@ function pushPendingTags() {
         console.log('Could not push tags(s) to origin.');
         process.exitCode = 1;
         return;
-      };
-      if (exec('git pull origin --rebase && git push origin --tags').status != 0) {
+      }
+      if (
+        exec('git pull origin --rebase && git push origin --tags').status != 0
+      ) {
         --retries;
-        console.log(`Push failed. Retrying in ${delaySec} seconds...`)
+        console.log(`Push failed. Retrying in ${delaySec} seconds...`);
         setTimeout(pushCommits, delaySec * 1000);
       }
-    }
+    };
     pushTags();
   }
 }
-
 
 module.exports = {
   getOsName,
   pushPendingCommits,
   pushPendingTags,
-}
+};

--- a/test/compiler.js
+++ b/test/compiler.js
@@ -21,72 +21,71 @@
  * @author Kristofer Baxter (kristofer@kristoferbaxter.com)
  */
 
-"use strict";
+'use strict';
 
-const assert = require("assert");
-const {
-  compiler: Compiler,
-} = require("../packages/google-closure-compiler");
-const packageInfo = require("../package.json");
-const Semver = require("semver");
-const compilerVersionMatch = require("./version-match.js");
-const spawn = require("child_process").spawnSync;
-require("mocha");
+const assert = require('assert');
+const {compiler: Compiler} = require('../packages/google-closure-compiler');
+const packageInfo = require('../package.json');
+const Semver = require('semver');
+const compilerVersionMatch = require('./version-match.js');
+const spawn = require('child_process').spawnSync;
+require('mocha');
 
-process.on("unhandledRejection", (e) => {
+process.on('unhandledRejection', (e) => {
   throw e;
 });
 
-describe("compiler.jar", function () {
+describe('compiler.jar', function () {
   this.timeout(10000);
   this.slow(5000);
 
-  it("should not be a snapshot build", (done) => {
-    const compiler = new Compiler({ version: true });
+  it('should not be a snapshot build', (done) => {
+    const compiler = new Compiler({version: true});
     compiler.run(function (exitCode, stdout, stderr) {
-      let versionInfo = (stdout || "").match(compilerVersionMatch);
+      let versionInfo = (stdout || '').match(compilerVersionMatch);
       assert.notEqual(versionInfo, null);
       versionInfo = versionInfo || [];
       assert.equal(versionInfo.length, 2);
-      assert.strictEqual(versionInfo[1].indexOf("SNAPSHOT") < 0, true);
+      assert.strictEqual(versionInfo[1].indexOf('SNAPSHOT') < 0, true);
       done();
     });
   });
 
-  it("version should be equal to the package major version", (done) => {
-    const compiler = new Compiler({ version: true });
+  it('version should be equal to the package major version', (done) => {
+    const compiler = new Compiler({version: true});
     compiler.run(function (exitCode, stdout, stderr) {
-      let versionInfo = (stdout || "").match(compilerVersionMatch);
+      let versionInfo = (stdout || '').match(compilerVersionMatch);
       assert.notEqual(versionInfo, null);
       versionInfo = versionInfo || [];
       assert.equal(versionInfo.length, 2);
 
-      assert.notEqual(Semver.valid(versionInfo[1] + ".0.0"), null);
+      assert.notEqual(Semver.valid(versionInfo[1] + '.0.0'), null);
       assert.strictEqual(
-        Semver.major(versionInfo[1] + ".0.0"),
-        Semver.major(packageInfo.dependencies["google-closure-compiler-java"])
+        Semver.major(versionInfo[1] + '.0.0'),
+        Semver.major(packageInfo.dependencies['google-closure-compiler-java'])
       );
       done();
     });
   });
 });
 
-describe("compiler submodule", function () {
+describe('compiler submodule', function () {
   this.timeout(10000);
   this.slow(5000);
 
   // TODO (KB): Restore this test it's failing on the get tag spawn.
-  it.skip("should be synced to the tagged commit", function () {
-    const gitCmd = spawn("git", ["tag", "--points-at", "HEAD"], {
-      cwd: "./compiler",
+  it.skip('should be synced to the tagged commit', function () {
+    const gitCmd = spawn('git', ['tag', '--points-at', 'HEAD'], {
+      cwd: './compiler',
     });
     assert.equal(gitCmd.status, 0);
-    const currentTag = gitCmd.stdout.toString().replace(/\s/g, "");
-    const mvnVersion = "v" +
-      Semver.major(packageInfo.dependencies["google-closure-compiler-java"]);
+    const currentTag = gitCmd.stdout.toString().replace(/\s/g, '');
+    const mvnVersion =
+      'v' +
+      Semver.major(packageInfo.dependencies['google-closure-compiler-java']);
     let normalizedTag = currentTag;
     if (normalizedTag) {
-      normalizedTag = currentTag.replace(/^([-a-z]+-)?(v\d{8})(.*)$/, "$2");
+      normalizedTag = currentTag.replace(/^([-a-z]+-)?(v\d{8})(.*)$/, '$2');
     }
     assert.equal(normalizedTag, mvnVersion);
   });


### PR DESCRIPTION
**PR Highlights:**

- Enables Prettier for `amp-closure-compiler`
- Ignores `packages/google-closure-compiler/` and `third_party/` (contains 3p / forked code)
- Auto-formats all code maintained by `ampproject@` with Prettier
