### PR TITLE
Make native binary updates less noisy

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -8,7 +8,10 @@ on:
       - master
 jobs:
   build-test-push:
-    if: ${{ !contains(github.event.head_commit.message, 'skip CI') }}
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'v202')) ||
+      (github.event_name == 'push' && contains(github.event.head_commit.message, '[UPDATE]'))
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
As of today, we update the closure native binaries for every kind of PR, unless the commit message contains `[skip CI]`. This has proven to be cumbersome and noisy.

This PR changes the logic to the following:
- For PRs: build, test, and verify native binaries for all platforms (but do not commit them to the repo)
- For push builds: do the above steps and commit the binaries if:
    - The commit text starts with `v202` (closure version upgrade)
    - The commit text contains `[UPDATE]` (a way to force an update)

With this, we should see fewer useless native binary updates.