### PR TITLE
Disable auto-upgrades for subpackages

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -4,14 +4,15 @@
     "supportPolicy": ["lts_latest"]
   },
   "commitMessagePrefix": "📦",
+  "ignorePaths": ["packages/**", "node_modules/**"],
   "packageRules": [
     {
-      "paths": ["package.json"],
+      "paths": ["+(package.json)"],
       "depTypeList": ["devDependencies"],
       "groupName": "Dev Dependencies"
     },
     {
-      "paths": ["package.json"],
+      "paths": ["+(package.json)"],
       "packageNames": ["google-closure-compiler-java"],
       "groupName": "Closure Compiler"
     }


### PR DESCRIPTION
**PR Highlights:**
- Disable renovate auto-upgrades for `package.json` files in `packages/` and `node_modules/`
- Explicitly enable auto-upgrades for `dependencies` and `devDependencies` in the root `package.json`

This will prevent spurious PRs like [these](https://github.com/ampproject/amp-closure-compiler/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed+%22Roll+back+dependency%22).