### PR TITLE
Refine dependency installs and binary push logic

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -10,7 +10,7 @@ jobs:
   build-test-push:
     if: |
       github.event_name == 'pull_request' ||
-      (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'v202')) ||
+      (github.event_name == 'push' && contains(github.event.head_commit.message, 'v202')) ||
       (github.event_name == 'push' && contains(github.event.head_commit.message, '[UPDATE]'))
     strategy:
       matrix:

--- a/packages/google-closure-compiler/package-lock.json
+++ b/packages/google-closure-compiler/package-lock.json
@@ -1,0 +1,149 @@
+{
+  "name": "@ampproject/google-closure-compiler",
+  "version": "20201207.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@ampproject/google-closure-compiler-java": {
+      "version": "20201207.0.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-java/-/google-closure-compiler-java-20201207.0.0.tgz",
+      "integrity": "sha512-q4PZ4uDhIG417aA9nUvcoA1jW7inO8RRV7Rbe4Po7AXQ3lrzBnKJ0iUgXrqGLGU5EIBW0RiHhmHhSPokyMrzkw=="
+    },
+    "@ampproject/google-closure-compiler-linux": {
+      "version": "20201207.0.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-linux/-/google-closure-compiler-linux-20201207.0.0.tgz",
+      "integrity": "sha512-k7QFhXkg0eMhImYeIjvG7LiE+DzRg95kbOmWfr+wImayoHHroiLqzrmpOqxTes0huPsAD5QV7nih6yrVegfuKQ==",
+      "optional": true
+    },
+    "@ampproject/google-closure-compiler-osx": {
+      "version": "20201207.0.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-osx/-/google-closure-compiler-osx-20201207.0.0.tgz",
+      "integrity": "sha512-hBNB/m/T7ddqXFPekH0aiFBcRcuXOBd4g25WVXvJ8IJy/y23U2v56kvE3dizMup9bgvucBZCSA3KQ7Ths9ExPA==",
+      "optional": true
+    },
+    "@ampproject/google-closure-compiler-windows": {
+      "version": "20201207.0.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-windows/-/google-closure-compiler-windows-20201207.0.0.tgz",
+      "integrity": "sha512-3Tw4MhEGFHiteaLVPSIrNrinJ75M51qbNYifwodYe72D99tEyLRaJrLAwvUewaQmlslMnnlD4Hk/9jlxli5tbQ==",
+      "optional": true
+    },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
+    "clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
+    },
+    "clone-stats": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+    },
+    "cloneable-readable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
+      "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^2.0.0",
+        "readable-stream": "^2.3.5"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "kleur": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA=="
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+    },
+    "replace-ext": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
+      "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw=="
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "vinyl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
+      "integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
+      "requires": {
+        "clone": "^2.1.1",
+        "clone-buffer": "^1.0.0",
+        "clone-stats": "^1.0.0",
+        "cloneable-readable": "^1.0.0",
+        "remove-trailing-separator": "^1.0.1",
+        "replace-ext": "^1.0.0"
+      }
+    },
+    "vinyl-sourcemaps-apply": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+      "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+      "requires": {
+        "source-map": "^0.5.1"
+      }
+    }
+  }
+}

--- a/packages/google-closure-compiler/package.json
+++ b/packages/google-closure-compiler/package.json
@@ -16,7 +16,10 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@ampproject/google-closure-compiler-java": "20201207.0.0"
+    "@ampproject/google-closure-compiler-java": "20201207.0.0",
+    "kleur": "4.1.4",
+    "vinyl": "2.2.1",
+    "vinyl-sourcemaps-apply": "0.2.1"
   },
   "optionalDependencies": {
     "@ampproject/google-closure-compiler-linux": "20201207.0.0",


### PR DESCRIPTION
**Two changes:**

- Add deps of `packages/google-closure-compiler` to its `package.json` (so they accompany the `npm` package)
- Push new binaries when `renovate` updates closure (e.g. `📦 Update dependency google-closure-compiler-java to v20210202`)