### PR TITLE
Require a AMP_MODE=true flag to enable AMP Pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,20 @@ If you're looking to use Closure Compiler for your project, here are some great 
     cd amp-closure-compiler
     npm install # This will create node_modules/google-closure-compiler-java/compiler.jar
     ```
-1. Clone https://github.com/google/closure-compiler/ (`google/closure-compiler`)
-    ```sh
-    git clone git@github.com:google/closure-compiler.git
-    ```
-1. Make your edits to `google/closure-compiler`
-1. [Build](https://github.com/google/closure-compiler/#using-bazel) `google/closure-compiler`
-1. Link your built `google/closure-compiler` to `amp-closure-compiler`'s `compiler.jar`
-    ```sh
-    # Run this from your source root directory
-    ln -s closure-compiler/bazel-bin/compiler_unshaded_deploy.jar \
-    amp-closure-compiler/node_modules/google-closure-compiler-java/compiler.jar
-    ```
+1. Make your edits
+   1. If you want to make changes to Google Closure Compiler itself:
+      1. Clone https://github.com/google/closure-compiler/ (`google/closure-compiler`)
+          ```sh
+          git clone git@github.com:google/closure-compiler.git
+          ```
+      1. Make your edits to `google/closure-compiler`
+      1. [Build](https://github.com/google/closure-compiler/#using-bazel) `google/closure-compiler`
+      1. Link your built `google/closure-compiler` to `amp-closure-compiler`'s `compiler.jar`
+          ```sh
+          # Run this from your source root directory
+          ln -s closure-compiler/bazel-bin/compiler_unshaded_deploy.jar \
+          amp-closure-compiler/node_modules/google-closure-compiler-java/compiler.jar
+          ```
 1. Build `amp-closure-compiler`
     ```sh
     npm run clean
@@ -41,7 +43,7 @@ If you're looking to use Closure Compiler for your project, here are some great 
     ```sh
     for dir in `ls packages/`;
     do;
-      cd dir;
+      cd packages/$dir;
       npm link;
       cd ../..;
     done

--- a/src/org/ampproject/AmpCommandLineRunner.java
+++ b/src/org/ampproject/AmpCommandLineRunner.java
@@ -74,7 +74,9 @@ public class AmpCommandLineRunner extends CommandLineRunner {
   @Override protected void setRunOptions(CompilerOptions options)
       throws IOException, FlagUsageException {
     super.setRunOptions(options);
-    options.setCodingConvention(new AmpCodingConvention());
+    if (amp_mode) {
+      options.setCodingConvention(new AmpCodingConvention());
+    }
   }
 
   /**

--- a/src/org/ampproject/AmpCommandLineRunner.java
+++ b/src/org/ampproject/AmpCommandLineRunner.java
@@ -37,11 +37,19 @@ public class AmpCommandLineRunner extends CommandLineRunner {
 
   private boolean pseudo_names = false;
 
+  /**
+   * AMP config and AmpCodingConvention must be specifically enabled by passing AMP_MODE=true
+   */
+  private boolean amp_mode = false;
+
   protected AmpCommandLineRunner(String[] args) {
     super(args);
   }
 
   @Override protected CompilerOptions createOptions() {
+    if (!amp_mode) {
+      return super.createOptions();
+    }
     if (typecheck_only) {
       return createTypeCheckingOptions();
     }
@@ -83,7 +91,9 @@ public class AmpCommandLineRunner extends CommandLineRunner {
     AmpCommandLineRunner runner = new AmpCommandLineRunner(args);
 
     for (String arg : args) {
-      if (arg.contains("TYPECHECK_ONLY=true")) {
+      if (arg.contains("AMP_MODE=true")) {
+        runner.amp_mode = true;
+      } else if (arg.contains("TYPECHECK_ONLY=true")) {
         runner.typecheck_only = true;
       } else if (arg.contains("PSEUDO_NAMES=true")) {
         runner.pseudo_names = true;


### PR DESCRIPTION
Trying to resolve yaqs/1882487052054822912#a1n7. This will require a similar change to the AMP invocation, which I'll do in a PR shortly.