### PR TITLE
Rename default branch to `main`

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -2,10 +2,10 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   build-test-push:
     if: |


### PR DESCRIPTION
Related to #61

I'm going to merge this soon as the branch is renamed.