### PR TITLE
Enable auto-merge for `amp-closure-compiler` upgrades that pass CI

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -7,14 +7,18 @@
   "ignorePaths": ["packages/**", "node_modules/**"],
   "packageRules": [
     {
-      "paths": ["+(package.json)"],
+      "groupName": "Dev Dependencies",
+      "matchFiles": ["package.json"],
       "depTypeList": ["devDependencies"],
-      "groupName": "Dev Dependencies"
+      "automerge": true,
+      "assignAutomerge": true
     },
     {
-      "paths": ["+(package.json)"],
+      "groupName": "Closure Compiler",
+      "matchFiles": ["package.json"],
       "packageNames": ["google-closure-compiler-java"],
-      "groupName": "Closure Compiler"
+      "automerge": true,
+      "assignAutomerge": true
     }
   ]
 }


### PR DESCRIPTION
We already have a CI workflow to ensure that binaries for all platforms are successfully built and pass all tests.

This PR will auto-merge package upgrades that pass CI. This way, they won't languish because no one came in to manually merge them.

With this, closure upgrades that pass all tests will get auto-merged to this repo. The step to publish `@ampproject/google-closure-compiler*` to npm is still manual, and provides us with a final layer of manual verification.
